### PR TITLE
Cross-platform safe temp file

### DIFF
--- a/dp_creator_ii/utils/argparse_helpers.py
+++ b/dp_creator_ii/utils/argparse_helpers.py
@@ -5,6 +5,7 @@ import csv
 import random
 from warnings import warn
 from collections import namedtuple
+from tempfile import mkdtemp
 
 
 def _existing_csv_type(arg):
@@ -81,10 +82,11 @@ def _get_demo_csv_contrib():
     """
     random.seed(0)  # So the mock data will be stable across runs.
 
-    csv_path = "/tmp/demo.csv"
+    # FYI: This is not deleted on exit.
+    csv_path = Path(mkdtemp(prefix="dp-creator")) / "demo.csv"
     contributions = 10
 
-    with open(csv_path, "w", newline="") as demo_handle:
+    with csv_path.open("w", newline="") as demo_handle:
         fields = ["student_id", "class_year", "hw_number", "grade"]
         writer = csv.DictWriter(demo_handle, fieldnames=fields)
         writer.writeheader()


### PR DESCRIPTION
- Fix #141 
- On the good side, this is more likely to work on Windows
- On the bad side, a new temp directory is created on every run
  - We could clean it up in the `session.on_ended` handler, but I'm not sure the complexity is worth it?

time: ~1 hour, mostly thinking about different options.