### PR TITLE
Write to a relative temp dir

### DIFF
--- a/dp_wizard/tmp/.gitignore
+++ b/dp_wizard/tmp/.gitignore
@@ -1,0 +1,1 @@
+demo.csv

--- a/dp_wizard/utils/argparse_helpers.py
+++ b/dp_wizard/utils/argparse_helpers.py
@@ -81,10 +81,10 @@ def _get_demo_csv_contrib():
     """
     random.seed(0)  # So the mock data will be stable across runs.
 
-    csv_path = "/tmp/demo.csv"
+    csv_path = Path(__file__).parent.parent / "tmp" / "demo.csv"
     contributions = 10
 
-    with open(csv_path, "w", newline="") as demo_handle:
+    with csv_path.open("w", newline="") as demo_handle:
         fields = ["student_id", "class_year", "hw_number", "grade"]
         writer = csv.DictWriter(demo_handle, fieldnames=fields)
         writer.writeheader()


### PR DESCRIPTION
- Fix #141 
- Replace #146

Might also use this for uploaded files. Currently if you upload a file through the UI, the path is a really obscure temp directory, and that's what we end up showing in the notebook. A scratch space that's local to the code might be a better solution.