### PR TITLE
Explain confidence interval

### DIFF
--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -5,6 +5,7 @@ from shiny import ui, reactive, render, req
 from dp_wizard.app.components.inputs import log_slider
 from dp_wizard.app.components.column_module import column_ui, column_server
 from dp_wizard.utils.csv_helper import read_csv_ids_labels, read_csv_ids_names
+from dp_wizard.utils.dp_helper import confidence
 from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
 from dp_wizard.utils.code_generators import make_privacy_loss_block
 from dp_wizard.app.components.column_module import col_widths
@@ -110,6 +111,14 @@ def analysis_server(
                 weights=weights,
                 is_demo=is_demo,
             )
+        confidence_percent = f"{int(confidence * 100)}%"
+        note_md = f"""
+        This simulation assumes a normal distribution between the specified
+        lower and upper bounds. Your CSV has not been read except to
+        determine the columns.
+
+        The confidence interval is {confidence_percent}.
+        """
         return [
             [
                 [
@@ -122,17 +131,7 @@ def analysis_server(
                 (
                     ui.layout_columns(
                         [],
-                        [
-                            ui.markdown(
-                                """
-                            This simulation assumes a normal
-                            distribution between the specified
-                            lower and upper bounds. Your data
-                            file has not been read except to
-                            determine the columns.
-                            """
-                            )
-                        ],
+                        [ui.markdown(note_md)],
                         col_widths=col_widths,
                     )
                     if column_ids

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -2,7 +2,7 @@ from logging import info
 
 from shiny import ui, render, module, reactive
 
-from dp_wizard.utils.dp_helper import make_confidence_accuracy_histogram
+from dp_wizard.utils.dp_helper import make_accuracy_histogram
 from dp_wizard.utils.shared import plot_histogram
 from dp_wizard.utils.code_generators import make_column_config_block
 from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
@@ -155,7 +155,7 @@ def column_server(
             # This function is triggered when column is removed;
             # Exit early to avoid divide-by-zero.
             return None
-        _confidence, accuracy, histogram = make_confidence_accuracy_histogram(
+        accuracy, histogram = make_accuracy_histogram(
             lower=lower_x,
             upper=upper_x,
             bin_count=bin_count,

--- a/dp_wizard/utils/code_generators/__init__.py
+++ b/dp_wizard/utils/code_generators/__init__.py
@@ -76,7 +76,11 @@ class _CodeGenerator(ABC):
         )
 
     def _make_queries(self, column_names):
-        return f"confidence = {confidence}\n\n" + "\n".join(
+        confidence_note = (
+            "The actual value is within the shown range "
+            f"with {int(confidence * 100)}% confidence."
+        )
+        return f"confidence = {confidence} # {confidence_note}\n\n" + "\n".join(
             _make_query(column_name) for column_name in column_names
         )
 

--- a/dp_wizard/utils/code_generators/__init__.py
+++ b/dp_wizard/utils/code_generators/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 from dp_wizard.utils.csv_helper import name_to_identifier
 from dp_wizard.utils.code_generators._template import Template
+from dp_wizard.utils.dp_helper import confidence
 
 
 class AnalysisPlanColumn(NamedTuple):
@@ -75,7 +76,7 @@ class _CodeGenerator(ABC):
         )
 
     def _make_queries(self, column_names):
-        return "confidence = 0.95\n\n" + "\n".join(
+        return f"confidence = {confidence}\n\n" + "\n".join(
             _make_query(column_name) for column_name in column_names
         )
 

--- a/dp_wizard/utils/dp_helper.py
+++ b/dp_wizard/utils/dp_helper.py
@@ -7,15 +7,16 @@ from dp_wizard.utils.shared import make_cut_points
 dp.enable_features("contrib")
 
 
-def make_confidence_accuracy_histogram(
+confidence = 0.95
+
+
+def make_accuracy_histogram(
     lower=None, upper=None, bin_count=None, contributions=None, weighted_epsilon=None
 ):
     """
     Creates fake data between lower and upper, and then returns a DP histogram from it.
-    >>> confidence, accuracy, histogram = make_confidence_accuracy_histogram(
+    >>> accuracy, histogram = make_accuracy_histogram(
     ...     lower=0, upper=10, bin_count=5, contributions=1, weighted_epsilon=1)
-    >>> confidence
-    0.95
     >>> accuracy
     3.37...
     >>> histogram
@@ -68,7 +69,6 @@ def make_confidence_accuracy_histogram(
     )
     query = context.query().group_by("bin").agg(pl.len().dp.noise())
 
-    confidence = 0.95
     accuracy = query.summarize(alpha=1 - confidence)["accuracy"].item()
     histogram = query.release().collect().sort("bin")
-    return (confidence, accuracy, histogram)
+    return (accuracy, histogram)


### PR DESCRIPTION
- Fix #153.
- My sense is that the confidence interval is not something we want to control in the UI: It's the kind of detail that is best left for the user to tweak in the notebook.

For the reviewer:
- Does a short comment in the UI (where we want to avoid distractions) and a longer note in the notebook (where we want to really explain things) make sense?
- Do you think explanation is needed anywhere else? Could add a comment to the graphs, but I'd worry about clutter.