### PR TITLE
Hide weight if only one column selected

### DIFF
--- a/WHAT-WE-LEARNED.md
+++ b/WHAT-WE-LEARNED.md
@@ -2,6 +2,10 @@
 
 Even if it seems obvious in retrospect, what have we learned about Python Shiny in this project?
 
+## Some basic html attributes are not supported
+
+I can mark a button as disabled, but it doesn't seem that a `ui.input_select` can be disabled.
+
 ## No warning if ID mismatch / type mismatch
 
 Unless I'm missing something, there doesn't seem to be any warning when there isn't a matching function name in the server for an ID in the UI. Either from typos, or fumbling some more complicated display logic, there have been times where this could have been helpful.

--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -109,6 +109,7 @@ def analysis_server(
                 bin_counts=bin_counts,
                 weights=weights,
                 is_demo=is_demo,
+                is_single_column=len(column_ids) == 1,
             )
         return [
             [

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -59,6 +59,7 @@ def column_server(
     bin_counts,
     weights,
     is_demo,
+    is_single_column,
 ):  # pragma: no cover
     @reactive.effect
     def _set_all_inputs():
@@ -117,7 +118,7 @@ def column_server(
 
     @render.ui
     def optional_weight_ui():
-        return ui.input_select(
+        weight_select = ui.input_select(
             "weight",
             ["Weight", ui.output_ui("weight_tooltip_ui")],
             choices={
@@ -127,6 +128,11 @@ def column_server(
             },
             selected=default_weight,
             width=label_width,
+        )
+        return (
+            weight_select
+            if not is_single_column
+            else [weight_select, "Weight doesn't matter with only one column."]
         )
 
     @render.ui

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -9,7 +9,7 @@ from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
 
 
 default_weight = 2
-
+label_width = "10em"  # Just wide enough so the text isn't trucated.
 col_widths = {
     # Controls stay roughly a constant width;
     # Graph expands to fill space.
@@ -21,29 +21,21 @@ col_widths = {
 
 @module.ui
 def column_ui():  # pragma: no cover
-    width = "10em"  # Just wide enough so the text isn't trucated.
     return ui.layout_columns(
         [
             # The initial values on these inputs
             # should be overridden by the reactive.effect.
             ui.input_numeric(
-                "lower", ["Lower", ui.output_ui("bounds_tooltip_ui")], 0, width=width
+                "lower",
+                ["Lower", ui.output_ui("bounds_tooltip_ui")],
+                0,
+                width=label_width,
             ),
-            ui.input_numeric("upper", "Upper", 0, width=width),
+            ui.input_numeric("upper", "Upper", 0, width=label_width),
             ui.input_numeric(
-                "bins", ["Bins", ui.output_ui("bins_tooltip_ui")], 0, width=width
+                "bins", ["Bins", ui.output_ui("bins_tooltip_ui")], 0, width=label_width
             ),
-            ui.input_select(
-                "weight",
-                ["Weight", ui.output_ui("weight_tooltip_ui")],
-                choices={
-                    1: "Less accurate",
-                    default_weight: "Default",
-                    4: "More accurate",
-                },
-                selected=default_weight,
-                width=width,
-            ),
+            ui.output_ui("optional_weight_ui"),
         ],
         [
             ui.output_plot("column_plot", height="300px"),
@@ -121,6 +113,20 @@ def column_server(
             the same overall privacy guarantee. For this example, give
             "class_year" 4 bins and "grade" 5 bins.
             """,
+        )
+
+    @render.ui
+    def optional_weight_ui():
+        return ui.input_select(
+            "weight",
+            ["Weight", ui.output_ui("weight_tooltip_ui")],
+            choices={
+                1: "Less accurate",
+                default_weight: "Default",
+                4: "More accurate",
+            },
+            selected=default_weight,
+            width=label_width,
         )
 
     @render.ui

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -5,7 +5,7 @@ from shiny import ui, render, module, reactive
 from dp_wizard.utils.dp_helper import make_confidence_accuracy_histogram
 from dp_wizard.utils.shared import plot_histogram
 from dp_wizard.utils.code_generators import make_column_config_block
-from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
+from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip, hide_if
 
 
 default_weight = 2
@@ -118,21 +118,19 @@ def column_server(
 
     @render.ui
     def optional_weight_ui():
-        weight_select = ui.input_select(
-            "weight",
-            ["Weight", ui.output_ui("weight_tooltip_ui")],
-            choices={
-                1: "Less accurate",
-                default_weight: "Default",
-                4: "More accurate",
-            },
-            selected=default_weight,
-            width=label_width,
-        )
-        return (
-            weight_select
-            if not is_single_column
-            else [weight_select, "Weight doesn't matter with only one column."]
+        return hide_if(
+            is_single_column,
+            ui.input_select(
+                "weight",
+                ["Weight", ui.output_ui("weight_tooltip_ui")],
+                choices={
+                    1: "Less accurate",
+                    default_weight: "Default",
+                    4: "More accurate",
+                },
+                selected=default_weight,
+                width=label_width,
+            ),
         )
 
     @render.ui

--- a/dp_wizard/app/components/outputs.py
+++ b/dp_wizard/app/components/outputs.py
@@ -17,3 +17,8 @@ def demo_tooltip(is_demo, text):  # pragma: no cover
             text,
             placement="right",
         )
+
+
+def hide_if(condition: bool, el):  # pragma: no cover
+    display = "none" if condition else "block"
+    return ui.div(el, style=f"display: {display};")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,6 +88,8 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # Set column details:
     page.get_by_label("grade").check()
     expect_visible(simulation)
+    weight_message = "Weight doesn't matter with only one column"
+    expect_visible(weight_message)
     # Check that default is set correctly:
     assert page.get_by_label("Upper").input_value() == "10"
     # Reset, and confirm:
@@ -100,8 +102,11 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     page.get_by_label("grade").check()
     expect_visible(simulation)
     assert page.get_by_label("Upper").input_value() == new_value
+    # Add a second column:
+    page.get_by_label("blank").check()
+    expect_not_visible(weight_message)
     # TODO: Setting more inputs without checking for updates
-    # cause recalculations to pile up, and these cause timeouts on CI:
+    # causes recalculations to pile up, and these cause timeouts on CI:
     # It is still rerendering the graph after hitting "Download results".
     # https://github.com/opendp/dp-wizard/issues/116
     expect_no_error()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,8 +88,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # Set column details:
     page.get_by_label("grade").check()
     expect_visible(simulation)
-    weight_message = "Weight doesn't matter with only one column"
-    expect_visible(weight_message)
+    expect_not_visible("Weight")
     # Check that default is set correctly:
     assert page.get_by_label("Upper").input_value() == "10"
     # Reset, and confirm:
@@ -104,7 +103,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     assert page.get_by_label("Upper").input_value() == new_value
     # Add a second column:
     page.get_by_label("blank").check()
-    expect_not_visible(weight_message)
+    expect_visible("Weight")
     # TODO: Setting more inputs without checking for updates
     # causes recalculations to pile up, and these cause timeouts on CI:
     # It is still rerendering the graph after hitting "Download results".


### PR DESCRIPTION
- Fix #136

Shiny doesn't seem to support disabling select controls. Not in the docs, and just adding a kwarg doesn't work. Adding a note after the control follows the pattern we have with disabled buttons. For both of these styling it as a [bootstrap alert](https://getbootstrap.com/docs/4.0/components/alerts/) might be appropriate.

For reviewer:
- Does this message seem worthwhile? or maybe it's a distraction if we can't easily disable the select?
- Would styling this message as an alert be appropriate? or would that call too much attention to it?

On the whole I think this is a good change, but I'm not totally confident about it. Feedback welcome.

---

Update: Instead of adding a message, just use a hidden div when there is only one column selected. PR retitled.