### PR TITLE
Let user set number of rows in simulated data

### DIFF
--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -28,6 +28,16 @@ def analysis_ui():
         ),
         ui.output_ui("columns_ui"),
         ui.markdown(
+            "What is the approximate number of rows in the dataset? "
+            "This number is only used for the preview and not the final calculation."
+        ),
+        ui.input_select(
+            "row_count",
+            "Approximate Rows",
+            choices=["100", "1000", "10000"],
+            selected="100",
+        ),
+        ui.markdown(
             "What is your privacy budget for this release? "
             "Values above 1 will add less noise to the data, "
             "but have a greater risk of revealing individual data."
@@ -108,6 +118,7 @@ def analysis_server(
                 name=column_ids_to_names[column_id],
                 contributions=contributions(),
                 epsilon=epsilon(),
+                row_count=int(input.row_count()),
                 lower_bounds=lower_bounds,
                 upper_bounds=upper_bounds,
                 bin_counts=bin_counts,
@@ -135,7 +146,7 @@ def analysis_server(
                 (
                     ui.layout_columns(
                         [],
-                        [ui.markdown(note_md)],
+                        ui.markdown(note_md),
                         col_widths=col_widths,  # type: ignore
                     )
                     if column_ids

--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -29,11 +29,11 @@ def analysis_ui():
         ui.output_ui("columns_ui"),
         ui.markdown(
             "What is the approximate number of rows in the dataset? "
-            "This number is only used for the preview and not the final calculation."
+            "This number is only used for the simulation and not the final calculation."
         ),
         ui.input_select(
             "row_count",
-            "Approximate Rows",
+            "Estimated Rows",
             choices=["100", "1000", "10000"],
             selected="100",
         ),

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -54,6 +54,7 @@ def column_server(
     name: str,
     contributions: int,
     epsilon: float,
+    row_count: int,
     lower_bounds: reactive.Value[dict[str, float]],
     upper_bounds: reactive.Value[dict[str, float]],
     bin_counts: reactive.Value[dict[str, int]],
@@ -166,6 +167,7 @@ def column_server(
             # Exit early to avoid divide-by-zero.
             return None
         accuracy, histogram = make_accuracy_histogram(
+            row_count=row_count,
             lower=lower_x,
             upper=upper_x,
             bin_count=bin_count,

--- a/dp_wizard/utils/dp_helper.py
+++ b/dp_wizard/utils/dp_helper.py
@@ -23,7 +23,12 @@ def make_accuracy_histogram(
     """
     Creates fake data between lower and upper, and then returns a DP histogram from it.
     >>> accuracy, histogram = make_accuracy_histogram(
-    ...     lower=0, upper=10, bin_count=5, contributions=1, weighted_epsilon=1)
+    ...     row_count=100,
+    ...     lower=0, upper=10,
+    ...     bin_count=5,
+    ...     contributions=1,
+    ...     weighted_epsilon=1
+    ... )
     >>> accuracy
     3.37...
     >>> histogram

--- a/dp_wizard/utils/dp_helper.py
+++ b/dp_wizard/utils/dp_helper.py
@@ -13,6 +13,7 @@ confidence = 0.95
 
 
 def make_accuracy_histogram(
+    row_count: int,
     lower: float,
     upper: float,
     bin_count: int,
@@ -42,7 +43,6 @@ def make_accuracy_histogram(
     # Mock data only depends on lower and upper bounds, so it could be cached,
     # but I'd guess this is dominated by the DP operations,
     # so not worth optimizing.
-    row_count = 100
     df = mock_data({"value": ColumnDef(lower, upper)}, row_count=row_count)
 
     # TODO: When this is stable, merge it to templates, so we can be

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,6 +85,10 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     download_results_button = page.get_by_role("button", name="Download results")
     assert download_results_button.is_disabled()
 
+    # Currently the only change when the estimated rows changes is the plot,
+    # but we could have the confidence interval in the text...
+    page.get_by_label("Estimated Rows").select_option("1000")
+
     # Set column details:
     page.get_by_label("grade").check()
     expect_visible(simulation)
@@ -103,7 +107,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     assert page.get_by_label("Upper").input_value() == new_value
     # Add a second column:
     page.get_by_label("blank").check()
-    expect_visible("Weight")
+    expect(page.get_by_text("Weight")).to_have_count(2)
     # TODO: Setting more inputs without checking for updates
     # causes recalculations to pile up, and these cause timeouts on CI:
     # It is still rerendering the graph after hitting "Download results".


### PR DESCRIPTION
- Fix #154

For the reviewer:
- Does the introduction to this option make sense?
- Is this a good set of choices? I was hoping that thinking in terms of orders of magnitude lessens the pressure on the user when coming up with an estimate, and that 10 is too small to be useful, while 100,000 is so large that the improvement is negligible, leaving us with 100, 1,000, and 10,000.