### PR TITLE
Check that it runs out of the box

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,10 @@ jobs:
           pip install pytest pytest-playwright
 
       - name: Install browsers
+        # TODO: Why doesn't work to just install chromium now?
         # Install just one browser instead of the default three.
         # https://playwright.dev/python/docs/browsers#managing-browser-binaries
-        run: playwright install chromium
+        run: playwright install
 
       - name: Run end-to-end test
         # We want to make sure there aren't hidden dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,15 +24,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install flit
-        run: pip install flit
+      - name: Install subset of dev deps
+        run: pip install flit pytest pytest-playwright
 
       - name: Install production deps
         run: flit install --deps production
-
-      - name: Install subset of test deps
-        run:
-          pip install pytest pytest-playwright
 
       - name: Install browsers
         # Install just one browser instead of the default three.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,22 +27,28 @@ jobs:
       - name: Install flit
         run: pip install flit
 
-      - name: Install package
-        run: flit install
+      - name: Install production deps
+        run: flit install --deps production
 
-      - name: Check CLI
-        # TODO: This won't catch most missing dependencies.
-        run: dp-wizard --help
-
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+      - name: Install subset of test deps
+        run:
+          pip install pytest pytest-playwright
 
       - name: Install browsers
         # Install just one browser instead of the default three.
         # https://playwright.dev/python/docs/browsers#managing-browser-binaries
         run: playwright install chromium
 
-      - name: Test
+      - name: Run end-to-end test
+        # We want to make sure there aren't hidden dependencies
+        # on dev tools in production code, and that it still works
+        # when dependencies aren't pinned.
+        run: pytest -k test_app
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run full tests
         run: ./ci.sh
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install subset of dev deps
-        run: pip install flit pytest pytest-playwright
+      - name: Install flit
+        run: pip install flit
 
       - name: Install production deps
         run: flit install --deps production
+
+      - name: Install subset of test deps
+        run:
+          pip install pytest pytest-playwright
 
       - name: Install browsers
         # Install just one browser instead of the default three.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,6 +23,10 @@ def test_demo_app(page: Page, demo_app: ShinyAppProc):  # pragma: no cover
 
 
 def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
+    # Default 5s timeout works for me in dev,
+    # but in CI or fresh venv it is slower.
+    expect.set_options(timeout=10_000)
+
     pick_dataset_text = "How many rows of the CSV"
     perform_analysis_text = "Select numeric columns of interest"
     download_results_text = "You can now make a differentially private release"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -100,16 +100,14 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     page.get_by_label("Upper").fill(new_value)
     # Uncheck the column:
     page.get_by_label("grade").uncheck()
-    # TODO: flaky?
-    # expect_not_visible(simulation)
+    expect_not_visible(simulation)
     # Recheck the column:
     page.get_by_label("grade").check()
     expect_visible(simulation)
     assert page.get_by_label("Upper").input_value() == new_value
     # Add a second column:
     page.get_by_label("blank").check()
-    # TODO: flaky?
-    # expect(page.get_by_text("Weight")).to_have_count(2)
+    expect(page.get_by_text("Weight")).to_have_count(2)
     # TODO: Setting more inputs without checking for updates
     # causes recalculations to pile up, and these cause timeouts on CI:
     # It is still rerendering the graph after hitting "Download results".

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -100,14 +100,16 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     page.get_by_label("Upper").fill(new_value)
     # Uncheck the column:
     page.get_by_label("grade").uncheck()
-    expect_not_visible(simulation)
+    # TODO: flaky?
+    # expect_not_visible(simulation)
     # Recheck the column:
     page.get_by_label("grade").check()
     expect_visible(simulation)
     assert page.get_by_label("Upper").input_value() == new_value
     # Add a second column:
     page.get_by_label("blank").check()
-    expect(page.get_by_text("Weight")).to_have_count(2)
+    # TODO: flaky?
+    # expect(page.get_by_text("Weight")).to_have_count(2)
     # TODO: Setting more inputs without checking for updates
     # causes recalculations to pile up, and these cause timeouts on CI:
     # It is still rerendering the graph after hitting "Download results".


### PR DESCRIPTION
- Fix #60: For the time being, it's an application... but we want to be sure not to get boxed in by overly strict version requirements.

This is checking two slightly different things:
- Can we run the end-to-end test with only a couple extra packages besides what a user would get when they install this package? We want to be sure that we aren't relying on dev dependencies in the production code by mistake.
- Can we run the end-to-end test with unpinned dependencies? We want to know if newer versions have introduced breaking changes. (We'll keep the pinned dependencies, too, so if something does go wrong with the unpinned deps, we know who is to blame.)