### PR TITLE
Include unit of privacy in graphs and output

### DIFF
--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -186,7 +186,10 @@ def column_server(
             weighted_epsilon=epsilon * weight / weights_sum,
         )
         s = "s" if contributions > 1 else ""
-        title = f"Simulated {name}: normal distribution, {contributions} contribution{s} / invidual"
+        title = (
+            f"Simulated {name}: normal distribution, "
+            f"{contributions} contribution{s} / invidual"
+        )
         return plot_histogram(
             histogram,
             error=accuracy,

--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -185,9 +185,11 @@ def column_server(
             contributions=contributions,
             weighted_epsilon=epsilon * weight / weights_sum,
         )
+        s = "s" if contributions > 1 else ""
+        title = f"Simulated {name}: normal distribution, {contributions} contribution{s} / invidual"
         return plot_histogram(
             histogram,
             error=accuracy,
             cutoff=0,  # TODO
-            title=f"Simulated {name}, assuming normal distribution",
+            title=title,
         )

--- a/dp_wizard/utils/code_generators/__init__.py
+++ b/dp_wizard/utils/code_generators/__init__.py
@@ -102,7 +102,6 @@ class _CodeGenerator(ABC):
 
     def _make_query(self, column_name):
         indentifier = name_to_identifier(column_name)
-        title = f"DP counts for {column_name}"
         accuracy_name = f"{indentifier}_accuracy"
         histogram_name = f"{indentifier}_histogram"
         return (
@@ -117,7 +116,7 @@ class _CodeGenerator(ABC):
             )
             .fill_blocks(
                 OUTPUT_BLOCK=self._make_output(
-                    title=title,
+                    column_name=column_name,
                     accuracy_name=accuracy_name,
                     histogram_name=histogram_name,
                 )
@@ -125,11 +124,11 @@ class _CodeGenerator(ABC):
             .finish()
         )
 
-    def _make_output(self, title: str, accuracy_name: str, histogram_name: str):
+    def _make_output(self, column_name: str, accuracy_name: str, histogram_name: str):
         return (
             Template(f"{self.root_template}_output")
             .fill_values(
-                TITLE=title,
+                COLUMN_NAME=column_name,
             )
             .fill_expressions(
                 ACCURACY_NAME=accuracy_name,

--- a/dp_wizard/utils/code_generators/no-tests/_notebook_output.py
+++ b/dp_wizard/utils/code_generators/no-tests/_notebook_output.py
@@ -1,2 +1,7 @@
 # CONFIDENCE_NOTE
-plot_histogram(HISTOGRAM_NAME, error=ACCURACY_NAME, cutoff=0, title=TITLE)
+column_name = COLUMN_NAME
+title = (
+    f"DP counts for {column_name}, "
+    f"assuming {contributions} contributions per invidual"
+)
+plot_histogram(HISTOGRAM_NAME, error=ACCURACY_NAME, cutoff=0, title=title)

--- a/dp_wizard/utils/code_generators/no-tests/_privacy_unit.py
+++ b/dp_wizard/utils/code_generators/no-tests/_privacy_unit.py
@@ -1,1 +1,2 @@
-privacy_unit = dp.unit_of(contributions=CONTRIBUTIONS)
+contributions = CONTRIBUTIONS
+privacy_unit = dp.unit_of(contributions=contributions)

--- a/dp_wizard/utils/code_generators/no-tests/_reports.py
+++ b/dp_wizard/utils/code_generators/no-tests/_reports.py
@@ -39,6 +39,7 @@ report = {
         "data": CSV_PATH,
         "epsilon": EPSILON,
         "columns": COLUMNS,
+        "contributions": contributions,
     },
     "outputs": OUTPUTS,
 }

--- a/dp_wizard/utils/code_generators/no-tests/_script.py
+++ b/dp_wizard/utils/code_generators/no-tests/_script.py
@@ -5,9 +5,9 @@ IMPORTS_BLOCK
 COLUMNS_BLOCK
 
 
-def get_context(csv_path):
+def get_context_contributions(csv_path):
     CONTEXT_BLOCK
-    return context
+    return context, contributions
 
 
 if __name__ == "__main__":
@@ -18,6 +18,6 @@ if __name__ == "__main__":
         "--csv", required=True, help="Path to csv containing private data"
     )
     args = parser.parse_args()
-    context = get_context(csv_path=args.csv)
+    context, contributions = get_context_contributions(csv_path=args.csv)
 
     QUERIES_BLOCK

--- a/dp_wizard/utils/code_generators/no-tests/_script_output.py
+++ b/dp_wizard/utils/code_generators/no-tests/_script_output.py
@@ -1,3 +1,7 @@
-print(TITLE)
+column_name = COLUMN_NAME
+print(
+    f"DP counts for {column_name}, "
+    f"assuming {contributions} contributions per invidual"
+)
 print(CONFIDENCE_NOTE, ACCURACY_NAME)
 print(HISTOGRAM_NAME)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -54,7 +54,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     expect_not_visible(download_results_text)
     page.get_by_label("Contributions").fill("42")
     page.get_by_text("Code sample: Unit of Privacy").click()
-    expect_visible("dp.unit_of(contributions=42)")
+    expect_visible("contributions = 42")
     expect_no_error()
 
     # Button disabled until upload:
@@ -156,7 +156,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
 
     script_download = script_download_info.value
     script = script_download.path().read_text()
-    assert "privacy_unit = dp.unit_of(contributions=42)" in script
+    assert "contributions = 42" in script
 
     # Notebook:
     with page.expect_download() as notebook_download_info:
@@ -165,7 +165,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
 
     notebook_download = notebook_download_info.value
     notebook = notebook_download.path().read_text()
-    assert "privacy_unit = dp.unit_of(contributions=42)" in notebook
+    assert "contributions = 42" in notebook
 
     # -- Feedback --
     page.get_by_text("Feedback").click()


### PR DESCRIPTION
- Fix #202 

Started with just the preview graphs, but then realized it should be included in the final outputs, too, though it does add some complexity.