### PR TITLE
Validate contributions

### DIFF
--- a/dp_wizard/app/components/outputs.py
+++ b/dp_wizard/app/components/outputs.py
@@ -22,3 +22,7 @@ def demo_tooltip(is_demo: bool, text: str):  # pragma: no cover
 def hide_if(condition: bool, el):  # pragma: no cover
     display = "none" if condition else "block"
     return ui.div(el, style=f"display: {display};")
+
+
+def info_box(text):  # pragma: no cover
+    return ui.div(text, class_="alert alert-info", role="alert")

--- a/dp_wizard/app/components/outputs.py
+++ b/dp_wizard/app/components/outputs.py
@@ -24,5 +24,5 @@ def hide_if(condition: bool, el):  # pragma: no cover
     return ui.div(el, style=f"display: {display};")
 
 
-def info_box(text):  # pragma: no cover
-    return ui.div(text, class_="alert alert-info", role="alert")
+def info_box(content):  # pragma: no cover
+    return ui.div(content, class_="alert alert-info", role="alert")

--- a/dp_wizard/app/dataset_panel.py
+++ b/dp_wizard/app/dataset_panel.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from shiny import ui, reactive, render, Inputs, Outputs, Session
 
 from dp_wizard.utils.argparse_helpers import get_cli_info
-from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
+from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip, info_box
 from dp_wizard.utils.code_generators import make_privacy_unit_block
 
 
@@ -25,11 +25,14 @@ def dataset_ui():
             "How many rows of the CSV can one individual contribute to? "
             'This is the "unit of privacy" which will be protected.'
         ),
-        ui.input_numeric(
-            "contributions",
-            ["Contributions", ui.output_ui("contributions_demo_tooltip_ui")],
-            cli_info.contributions,
-            min=1,
+        ui.row(
+            ui.input_numeric(
+                "contributions",
+                ["Contributions", ui.output_ui("contributions_demo_tooltip_ui")],
+                cli_info.contributions,
+                min=1,
+            ),
+            ui.output_ui("contributions_validation_ui"),
         ),
         ui.output_ui("python_tooltip_ui"),
         output_code_sample("Unit of Privacy", "unit_of_privacy_python"),
@@ -79,6 +82,10 @@ def dataset_server(
             "For the demo, we assume that each student "
             f"can occur at most {contributions()} times in the dataset. ",
         )
+
+    @render.ui
+    def contributions_validation_ui():
+        return info_box(ui.markdown("TODO: conditional warning here."))
 
     @render.ui
     def python_tooltip_ui():

--- a/dp_wizard/app/dataset_panel.py
+++ b/dp_wizard/app/dataset_panel.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from shiny import ui, reactive, render, Inputs, Outputs, Session
 
 from dp_wizard.utils.argparse_helpers import get_cli_info
-from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip, info_box
+from dp_wizard.app.components.outputs import (
+    output_code_sample,
+    demo_tooltip,
+    info_box,
+    hide_if,
+)
 from dp_wizard.utils.code_generators import make_privacy_unit_block
 
 
@@ -85,7 +90,11 @@ def dataset_server(
 
     @render.ui
     def contributions_validation_ui():
-        return info_box(ui.markdown("TODO: conditional warning here."))
+        contributions = input.contributions()
+        return hide_if(
+            isinstance(contributions, int) and contributions >= 1,
+            info_box(ui.markdown("Contributions must be 1 or greater.")),
+        )
 
     @render.ui
     def python_tooltip_ui():

--- a/dp_wizard/app/dataset_panel.py
+++ b/dp_wizard/app/dataset_panel.py
@@ -88,11 +88,15 @@ def dataset_server(
             f"can occur at most {contributions()} times in the dataset. ",
         )
 
+    @reactive.calc
+    def contributions_valid():
+        contributions = input.contributions()
+        return isinstance(contributions, int) and contributions >= 1
+
     @render.ui
     def contributions_validation_ui():
-        contributions = input.contributions()
         return hide_if(
-            isinstance(contributions, int) and contributions >= 1,
+            contributions_valid(),
             info_box(ui.markdown("Contributions must be 1 or greater.")),
         )
 
@@ -111,7 +115,7 @@ def dataset_server(
         button = ui.input_action_button(
             "go_to_analysis", "Define analysis", disabled=not button_enabled()
         )
-        if button_enabled():
+        if button_enabled() and contributions_valid():
             return button
         return [
             button,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,6 +68,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # Check validation of contributions:
     # Playwright itself won't let us fill non-numbers in this field.
     # "assert define_analysis_button.is_enabled()" has spurious errors.
+    # https://github.com/opendp/dp-wizard/issues/221
     page.get_by_label("Contributions").fill("0")
     expect_visible("Contributions must be 1 or greater")
     expect_visible("Choose CSV and Contributions before proceeding")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,6 +64,18 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # Now upload:
     csv_path = Path(__file__).parent / "fixtures" / "fake.csv"
     page.get_by_label("Choose CSV file").set_input_files(csv_path.resolve())
+
+    # Check validation of contributions:
+    # Playwright itself won't let us fill non-numbers in this field.
+    # "assert define_analysis_button.is_enabled()" has spurious errors.
+    page.get_by_label("Contributions").fill("0")
+    expect_visible("Contributions must be 1 or greater")
+    expect_visible("Choose CSV and Contributions before proceeding")
+
+    page.get_by_label("Contributions").fill("42")
+    expect_not_visible("Contributions must be 1 or greater")
+    expect_not_visible("Choose CSV and Contributions before proceeding")
+
     expect_no_error()
 
     # -- Define analysis --


### PR DESCRIPTION
- Fix #188

The user could also misfill Upper/Lower/Bins on the next tab, but in that case, there is an immediate error message, albeit an ugly one, so I'm inclined not to add more validation code there. 

For reviewer:
- Is this UI good enough?
- Ok not to investigate test flakiness (`define_analysis_button.is_disabled()`) more deeply?
- Confirmation that we're ok with Shiny's default error messages, where the error is obviously connected to the input?