### PR TITLE
Capture and show any error messages from notebook execution

### DIFF
--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import subprocess
 import json
-from logging import warning
+from warnings import warn
 
 
 def convert_py_to_nb(python_str: str, execute: bool = False):
@@ -36,7 +36,7 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
         try:
             result = subprocess.run(argv, check=True, text=True, capture_output=True)
         except subprocess.CalledProcessError as e:
-            warning(f'STDERR from "{cmd}":\n{e.stderr}')
+            warn(f'STDERR from "{cmd}":\n{e.stderr}')
             if not execute:
                 # Might reach here if jupytext is not installed.
                 # Error quickly instead of trying to recover.
@@ -50,7 +50,7 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
             result = subprocess.run(argv, check=True, text=True, capture_output=True)
 
         if result.stderr:
-            warning(f'STDERR from "{cmd}":\n{result.stderr}')  # pragma: no cover
+            warn(f'STDERR from "{cmd}":\n{result.stderr}')  # pragma: no cover
         return result.stdout.strip()
 
 

--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import subprocess
 import json
+from logging import warning
 
 
 def convert_py_to_nb(python_str: str, execute: bool = False):
@@ -31,9 +32,11 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
             + (["--execute"] if execute else [])
             + [str(py_path.absolute())]  # Input
         )
+        cmd = " ".join(argv)  # for error reporting
         try:
             result = subprocess.run(argv, check=True, text=True, capture_output=True)
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
+            warning(f'STDERR from "{cmd}":\n{e.stderr}')
             if not execute:
                 # Might reach here if jupytext is not installed.
                 # Error quickly instead of trying to recover.
@@ -46,6 +49,8 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
             )
             result = subprocess.run(argv, check=True, text=True, capture_output=True)
 
+        if result.stderr:
+            warning(f'STDERR from "{cmd}":\n{result.stderr}')  # pragma: no cover
         return result.stdout.strip()
 
 

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -61,5 +61,12 @@ def test_strip_nb_coda():
 
 def test_convert_py_to_nb_error():
     python_str = "Invalid python!"
-    with pytest.raises(subprocess.CalledProcessError):
-        convert_py_to_nb(python_str, execute=True)
+    with pytest.raises(
+        subprocess.CalledProcessError,
+        match=r"jupytext.*returned non-zero exit status",
+    ):
+        with pytest.warns(
+            UserWarning,
+            match=r'STDERR from "jupytext',
+        ):
+            convert_py_to_nb(python_str, execute=True)


### PR DESCRIPTION
- Fix #222

Note that [warnings.warn()](https://docs.python.org/3/library/warnings.html#warnings.warn) != [Logger.warning()](https://docs.python.org/3/library/logging.html#logging.Logger.warning). The former is what we're using.