### PR TITLE
Handle more columns in dataframe helper

### DIFF
--- a/dp_wizard/utils/shared.py
+++ b/dp_wizard/utils/shared.py
@@ -28,14 +28,23 @@ def df_to_columns(df: DataFrame):
     Transform a Dataframe into a format that is easier to plot,
     parsing the interval strings to sort them as numbers.
     >>> import polars as pl
-    >>> df = pl.DataFrame({
+    >>> df_2 = pl.DataFrame({
     ...     "bin": ["(-inf, 5]", "(10, 20]", "(5, 10]"],
     ...     "len": [0, 20, 10],
     ... })
-    >>> df_to_columns(df)
+    >>> df_to_columns(df_2)
     (('(-inf, 5]', '(5, 10]', '(10, 20]'), (0, 10, 20))
+
+    >>> df_3 = pl.DataFrame({
+    ...     "bin": ["(0, 1]", "(1, 2]", "(0, 1]", "(1, 2]"],
+    ...     "etc": ["A", "A", "B", "B"],
+    ...     "len": [0, 10, 20, 30],
+    ... })
+    >>> df_to_columns(df_3)
+    (('(0, 1] A', '(0, 1] B', '(1, 2] A', '(1, 2] B'), (0, 20, 10, 30))
     """
-    sorted_rows = sorted(df.rows(), key=lambda pair: interval_bottom(pair[0]))
+    merged_key_rows = [(" ".join(keys), value) for (*keys, value) in df.rows()]
+    sorted_rows = sorted(merged_key_rows, key=lambda row: interval_bottom(row[0]))
     return tuple(zip(*sorted_rows))
 
 

--- a/dp_wizard/utils/shared.py
+++ b/dp_wizard/utils/shared.py
@@ -27,21 +27,6 @@ def df_to_columns(df: DataFrame):
     """
     Transform a Dataframe into a format that is easier to plot,
     parsing the interval strings to sort them as numbers.
-    >>> import polars as pl
-    >>> df_2 = pl.DataFrame({
-    ...     "bin": ["(-inf, 5]", "(10, 20]", "(5, 10]"],
-    ...     "len": [0, 20, 10],
-    ... })
-    >>> df_to_columns(df_2)
-    (('(-inf, 5]', '(5, 10]', '(10, 20]'), (0, 10, 20))
-
-    >>> df_3 = pl.DataFrame({
-    ...     "bin": ["(0, 1]", "(1, 2]", "(0, 1]", "(1, 2]"],
-    ...     "etc": ["A", "A", "B", "B"],
-    ...     "len": [0, 10, 20, 30],
-    ... })
-    >>> df_to_columns(df_3)
-    (('(0, 1] A', '(0, 1] B', '(1, 2] A', '(1, 2] B'), (0, 20, 10, 30))
     """
     merged_key_rows = [(" ".join(keys), value) for (*keys, value) in df.rows()]
     sorted_rows = sorted(merged_key_rows, key=lambda row: interval_bottom(row[0]))

--- a/tests/utils/test_shared.py
+++ b/tests/utils/test_shared.py
@@ -1,0 +1,29 @@
+from dp_wizard.utils.shared import df_to_columns
+import polars as pl
+
+
+def test_2_df_to_columns():
+    df_2 = pl.DataFrame(
+        {
+            "bin": ["(-inf, 5]", "(10, 20]", "(5, 10]"],
+            "len": [0, 20, 10],
+        }
+    )
+    assert df_to_columns(df_2) == (
+        ("(-inf, 5]", "(5, 10]", "(10, 20]"),
+        (0, 10, 20),
+    )
+
+
+def test_3_df_to_columns():
+    df_3 = pl.DataFrame(
+        {
+            "bin": ["(0, 1]", "(1, 2]", "(0, 1]", "(1, 2]"],
+            "etc": ["A", "A", "B", "B"],
+            "len": [0, 10, 20, 30],
+        }
+    )
+    assert df_to_columns(df_3) == (
+        ("(0, 1] A", "(0, 1] B", "(1, 2] A", "(1, 2] B"),
+        (0, 20, 10, 30),
+    )


### PR DESCRIPTION
- Fix #238
- Will help with #237 

The idea is that rather than sorting out right now the details of how visualization will work when we have more keys (ie, should it be multiple plots? Or groups of columns? Or stacked columns? ...), we just concatenate the keys, and everything downstream works the same as before: Just one plain bar chart.

This code is included in the final notebook, and it is getting a little long, so move the test out.