### PR TITLE
no commas in compound predicates

### DIFF
--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -26,7 +26,7 @@ def analysis_ui():
                     Select columns to group by, or leave empty
                     to calculate statistics across the entire dataset.
 
-                    Groups aren't applied to the previews on this page,
+                    Groups aren't applied to the previews on this page
                     but will be used in the final release.
                     """
                 ),


### PR DESCRIPTION
An alternative to this PR is to have two independent clauses. Something like this:

"Groups aren't applied to the previews on this page, but they will be used in the final release."

https://www.grammar-monster.com/glossary/compound_predicate.htm