### PR TITLE
Use xdist for parallel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,6 @@ jobs:
         # https://playwright.dev/python/docs/browsers#managing-browser-binaries
         run: playwright install chromium
 
-      - name: Install kernel
-        # In normal usage, this should be run automatically for the user,
-        # but it doesn't work under xdist for parallel tests.
-        run: python -m ipykernel install --name kernel_name --user
-
       - name: Test
         run: ./ci.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,11 @@ jobs:
         # https://playwright.dev/python/docs/browsers#managing-browser-binaries
         run: playwright install chromium
 
+      - name: Install kernel
+        # In normal usage, this should be run automatically for the user,
+        # but it doesn't work under xdist for parallel tests.
+        run: python -m ipykernel install --name kernel_name --user
+
       - name: Test
         run: ./ci.sh
 

--- a/ci.sh
+++ b/ci.sh
@@ -2,4 +2,11 @@
 
 set -euo pipefail
 
-pytest -vv --failed-first --numprocesses=auto --cov=dp_wizard
+if [ -z ${CI+x} ]; then
+    echo "Run tests in parallel to save developer time. For single process: 'CI=true ./ci.sh'"
+    pytest -vv --failed-first --numprocesses=auto --cov=dp_wizard
+else
+    echo "Run tests in single process to avoid surprises."
+    coverage run -m pytest -vv --failed-first
+    coverage report
+fi

--- a/ci.sh
+++ b/ci.sh
@@ -2,5 +2,4 @@
 
 set -euo pipefail
 
-coverage run -m pytest -vv --failed-first
-coverage report
+pytest -vv --failed-first --numprocesses=auto --cov=dp_wizard

--- a/dp_wizard/utils/argparse_helpers.py
+++ b/dp_wizard/utils/argparse_helpers.py
@@ -78,7 +78,7 @@ def _get_args():
     if "pytest" in argv[0] or ("shiny" in argv[0] and "run" == argv[1]):
         # We are running a test,
         # and ARGV is polluted, so override:
-        args = arg_parser.parse_args([])
+        args = arg_parser.parse_args([])  # pragma: no cover
     else:
         # Normal parsing:
         args = arg_parser.parse_args()  # pragma: no cover

--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -29,7 +29,7 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
         cmd = " ".join(argv)  # for error reporting
         try:
             result = subprocess.run(argv, check=True, text=True, capture_output=True)
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError as e:  # pragma: no cover
             warn(f'STDERR from "{cmd}":\n{e.stderr}')
             if not execute:
                 # Might reach here if jupytext is not installed.

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,7 +14,8 @@ pre-commit
 pytest
 pytest-playwright
 pyright
-coverage
+pytest-cov
+pytest-xdist
 
 
 # Everything below should also be listed in pyproject.toml:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,8 +45,8 @@ comm==0.2.2
     # via ipykernel
 contourpy==1.3.1
     # via matplotlib
-coverage==7.6.12
-    # via -r requirements-dev.in
+coverage[toml]==7.6.12
+    # via pytest-cov
 cycler==0.12.1
     # via matplotlib
 debugpy==1.8.12
@@ -66,6 +66,8 @@ exceptiongroup==1.2.2
     #   anyio
     #   ipython
     #   pytest
+execnet==2.1.1
+    # via pytest-xdist
 executing==2.2.0
     # via stack-data
 faicons==0.2.2
@@ -263,10 +265,16 @@ pytest==8.3.4
     # via
     #   -r requirements-dev.in
     #   pytest-base-url
+    #   pytest-cov
     #   pytest-playwright
+    #   pytest-xdist
 pytest-base-url==2.1.0
     # via pytest-playwright
+pytest-cov==6.0.0
+    # via -r requirements-dev.in
 pytest-playwright==0.7.0
+    # via -r requirements-dev.in
+pytest-xdist==3.6.1
     # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
     # via
@@ -327,6 +335,7 @@ tomli==2.2.1
     # via
     #   black
     #   build
+    #   coverage
     #   jupytext
     #   pip-tools
     #   pytest

--- a/tests/utils/test_argparse_helpers.py
+++ b/tests/utils/test_argparse_helpers.py
@@ -34,16 +34,19 @@ def extract_block(md):
 
 
 def test_help():
-    help = (
-        re.sub(
-            r"\]\s+\[",
-            "] [",  # line wrapping of params varies.
-            _get_arg_parser().format_help(),
-        )
-        # argparse doesn't actually know the name of the script
-        # and inserts info from the running process instead.
-        .replace("usage: -c", "usage: dp-wizard")
-    ).strip()
+    help = re.sub(
+        # line wrapping of params varies:
+        r"\]\s+\[",
+        "] [",
+        _get_arg_parser().format_help(),
+    )
+    help = re.sub(
+        # argparse inserts info from the running process:
+        r"usage: (-c|__main__\.py|pytest)",
+        "usage: dp-wizard",
+        help,
+    )
+    help = help.strip()
 
     root_path = Path(__file__).parent.parent.parent
 

--- a/tests/utils/test_argparse_helpers.py
+++ b/tests/utils/test_argparse_helpers.py
@@ -41,8 +41,8 @@ def test_help():
             _get_arg_parser().format_help(),
         )
         # argparse doesn't actually know the name of the script
-        # and inserts the name of the running program instead.
-        .replace("__main__.py", "dp-wizard").replace("pytest", "dp-wizard")
+        # and inserts info from the running process instead.
+        .replace("usage: -c", "usage: dp-wizard")
     ).strip()
 
     root_path = Path(__file__).parent.parent.parent


### PR DESCRIPTION
- Fix #261

Tests run about twice as fast locally with this change. In the future, might improve this further by splitting up slow end-to-end tests.

Had one failure on CI that went away with a re-run: not sure if there's a deeper problem.

If this seems like a good change for developers, but a source of added complexity in CI, one option would be to make the behavior of `ci.sh` conditional. Open to suggestions.