### PR TITLE
check for kernel first, instead of falling back

### DIFF
--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -5,14 +5,16 @@ import json
 import nbformat
 import nbconvert
 from warnings import warn
-from logging import debug
+import jupytext
 
 
 def _is_kernel_installed() -> bool:
-    argv = "jupyter kernelspec list".split(" ")
-    result = subprocess.run(argv, check=True, text=True, capture_output=True)
-    lines = result.stdout.splitlines()
-    return any(line.strip().startswith("python3") for line in lines)
+    try:
+        # This method isn't well documented, so it may be fragile.
+        jupytext.kernels.kernelspec_from_language("python")  # type: ignore
+        return True
+    except ValueError:  # pragma: no cover
+        return False
 
 
 def convert_py_to_nb(python_str: str, execute: bool = False):
@@ -23,7 +25,7 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
     """
     with TemporaryDirectory() as temp_dir:
         if not _is_kernel_installed():
-            subprocess.run(
+            subprocess.run(  # pragma: no cover
                 "python -m ipykernel install --name kernel_name --user".split(" "),
                 check=True,
             )

--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -8,6 +8,13 @@ from warnings import warn
 from logging import debug
 
 
+def _is_kernel_installed() -> bool:
+    argv = "jupyter kernelspec list".split(" ")
+    result = subprocess.run(argv, check=True, text=True, capture_output=True)
+    lines = result.stdout.splitlines()
+    return any(line.strip().startswith("python3") for line in lines)
+
+
 def convert_py_to_nb(python_str: str, execute: bool = False):
     """
     Given Python code as a string, returns a notebook as a string.
@@ -15,6 +22,12 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
     Not ideal, but only the CLI is documented well.
     """
     with TemporaryDirectory() as temp_dir:
+        if not _is_kernel_installed():
+            subprocess.run(
+                "python -m ipykernel install --name kernel_name --user".split(" "),
+                check=True,
+            )
+
         temp_dir_path = Path(temp_dir)
         py_path = temp_dir_path / "input.py"
         py_path.write_text(python_str)
@@ -27,28 +40,10 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
             + (["--execute"] if execute else [])
             + [str(py_path.absolute())]  # Input
         )
-        cmd = " ".join(argv)  # for error reporting
-        try:
-            result = subprocess.run(argv, check=True, text=True, capture_output=True)
-        except subprocess.CalledProcessError as e:  # pragma: no cover
-            if not execute:
-                # Might reach here if jupytext is not installed.
-                # Error quickly instead of trying to recover.
-                raise  # pragma: no cover
-            # Install kernel if missing
-            warn("jupytext failed: Will install kernel and try again.")
-            # TODO: Revisit hiding the details with "debug":
-            # Hid information I needed when notebook eval failed.
-            # https://github.com/opendp/dp-wizard/issues/277
-            debug(f'STDERR from "{cmd}":\n{e.stderr}')
-            subprocess.run(
-                "python -m ipykernel install --name kernel_name --user".split(" "),
-                check=True,
-            )
-            result = subprocess.run(argv, check=True, text=True, capture_output=True)
-
-        if result.stderr:
-            warn(f'STDERR from "{cmd}":\n{result.stderr}')  # pragma: no cover
+        result = subprocess.run(argv, text=True, capture_output=True)
+        if result.returncode != 0:
+            warn(result.stderr)
+            raise Exception(f"command failed: {' '.join(argv)}")
         return _clean_nb(result.stdout.strip())
 
 

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -59,12 +59,12 @@ def test_clean_nb():
 def test_convert_py_to_nb_error():
     python_str = "Invalid python!"
     with pytest.raises(
-        subprocess.CalledProcessError,
-        match=r"jupytext.*returned non-zero exit status",
+        Exception,
+        match=r"command failed: jupytext --from \.py --to \.ipynb",
     ):
         with pytest.warns(
             UserWarning,
-            match=r"jupytext failed: Will install kernel and try again",
+            match=r"SyntaxError.*invalid syntax",
         ):
             convert_py_to_nb(python_str, execute=True)
 

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -1,6 +1,5 @@
 import re
 from pathlib import Path
-import subprocess
 import pytest
 import json
 from dp_wizard.utils.converters import (


### PR DESCRIPTION
- Fix #277

In the state before this PR, if there actually is an error in the generated code, it's hard to debug because we hide the warning, on the chance that the root problem is just a missing kernel.

The logic is simplified here, and we first check if the kernel is installed explicitly, and install if not, and then move on.