### PR TITLE
Add "about" tab

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -1,7 +1,7 @@
 # DP Wizard
 
 DP Wizard guides the user through the application of differential privacy.
-After selecting a local CSV, users are prompted to describe to the anlysis they need.
+After selecting a local CSV, users are prompted to describe the anlysis they need.
 Output options include:
 - A Jupyter notebook which demonstrates how to use [OpenDP](https://docs.opendp.org/).
 - A plain Python script.

--- a/dp_wizard/app/__init__.py
+++ b/dp_wizard/app/__init__.py
@@ -20,6 +20,7 @@ app_ui = ui.page_bootstrap(
         analysis_panel.analysis_ui(),
         results_panel.results_ui(),
         feedback_panel.feedback_ui(),
+        selected=dataset_panel.dataset_panel_id,
         id="top_level_nav",
     ),
     title="DP Wizard",

--- a/dp_wizard/app/__init__.py
+++ b/dp_wizard/app/__init__.py
@@ -3,12 +3,19 @@ from pathlib import Path
 from shiny import App, ui, reactive, Inputs, Outputs, Session
 
 from dp_wizard.utils.argparse_helpers import get_cli_info, CLIInfo
-from dp_wizard.app import analysis_panel, dataset_panel, results_panel, feedback_panel
+from dp_wizard.app import (
+    about_panel,
+    analysis_panel,
+    dataset_panel,
+    results_panel,
+    feedback_panel,
+)
 
 
 app_ui = ui.page_bootstrap(
     ui.head_content(ui.include_css(Path(__file__).parent / "css" / "styles.css")),
     ui.navset_tab(
+        about_panel.about_ui(),
         dataset_panel.dataset_ui(),
         analysis_panel.analysis_ui(),
         results_panel.results_ui(),
@@ -39,6 +46,11 @@ def make_server_from_cli_info(cli_info: CLIInfo):
         weights = reactive.value({})
         epsilon = reactive.value(1.0)
 
+        about_panel.about_server(
+            input,
+            output,
+            session,
+        )
         dataset_panel.dataset_server(
             input,
             output,

--- a/dp_wizard/app/about_panel.py
+++ b/dp_wizard/app/about_panel.py
@@ -28,7 +28,7 @@ def about_ui():
                 """
                 DP Wizard guides the user through the application of
                 differential privacy. After selecting a local CSV,
-                users are prompted to describe to the anlysis they need.
+                users are prompted to describe the anlysis they need.
                 Output options include:
                 - A Jupyter notebook which demonstrates how to use
                 [OpenDP](https://docs.opendp.org/).

--- a/dp_wizard/app/about_panel.py
+++ b/dp_wizard/app/about_panel.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typing import Optional
+
+from shiny import ui, reactive, render, Inputs, Outputs, Session
+
+from dp_wizard.utils.argparse_helpers import (
+    get_cli_info,
+    PUBLIC_TEXT,
+    PRIVATE_TEXT,
+    PUBLIC_PRIVATE_TEXT,
+)
+from dp_wizard.utils.csv_helper import get_csv_names_mismatch
+from dp_wizard.app.components.outputs import (
+    output_code_sample,
+    demo_tooltip,
+    hide_if,
+    info_box,
+)
+from dp_wizard.utils.code_generators import make_privacy_unit_block
+
+
+def about_ui():
+    return ui.nav_panel(
+        "About",
+        ui.card(
+            ui.card_header("About DP Wizard"),
+            ui.markdown(
+                """
+                DP Wizard guides the user through the application of
+                differential privacy. After selecting a local CSV,
+                users are prompted to describe to the anlysis they need.
+                Output options include:
+                - A Jupyter notebook which demonstrates how to use
+                [OpenDP](https://docs.opendp.org/).
+                - A plain Python script.
+                - Text and CSV reports.
+                """
+            ),
+        ),
+        ui.input_action_button("go_to_dataset", "Select dataset"),
+        value="about_panel",
+    )
+
+
+def about_server(
+    input: Inputs,
+    output: Outputs,
+    session: Session,
+):  # pragma: no cover
+    @reactive.effect
+    @reactive.event(input.go_to_dataset)
+    def go_to_analysis():
+        ui.update_navs("top_level_nav", selected="dataset_panel")

--- a/dp_wizard/app/about_panel.py
+++ b/dp_wizard/app/about_panel.py
@@ -5,6 +5,7 @@ from shiny import ui, reactive, Inputs, Outputs, Session
 
 
 def about_ui():
+    version = (Path(__file__).parent.parent / "VERSION").read_text()
     return ui.nav_panel(
         "About",
         ui.card(
@@ -21,9 +22,7 @@ def about_ui():
                 - Text and CSV reports.
                 """
             ),
-            ui.p(
-                f"DP Wizard version {(Path(__file__).parent.parent / 'VERSION').read_text()}"
-            ),
+            ui.p(f"DP Wizard version {version}"),
             ui.p(f"Python {sys.version}"),
         ),
         ui.input_action_button("go_to_dataset", "Select dataset"),

--- a/dp_wizard/app/about_panel.py
+++ b/dp_wizard/app/about_panel.py
@@ -1,22 +1,7 @@
+import sys
 from pathlib import Path
-from typing import Optional
 
-from shiny import ui, reactive, render, Inputs, Outputs, Session
-
-from dp_wizard.utils.argparse_helpers import (
-    get_cli_info,
-    PUBLIC_TEXT,
-    PRIVATE_TEXT,
-    PUBLIC_PRIVATE_TEXT,
-)
-from dp_wizard.utils.csv_helper import get_csv_names_mismatch
-from dp_wizard.app.components.outputs import (
-    output_code_sample,
-    demo_tooltip,
-    hide_if,
-    info_box,
-)
-from dp_wizard.utils.code_generators import make_privacy_unit_block
+from shiny import ui, reactive, Inputs, Outputs, Session
 
 
 def about_ui():
@@ -36,6 +21,10 @@ def about_ui():
                 - Text and CSV reports.
                 """
             ),
+            ui.p(
+                f"DP Wizard version {(Path(__file__).parent.parent / 'VERSION').read_text()}"
+            ),
+            ui.p(f"Python {sys.version}"),
         ),
         ui.input_action_button("go_to_dataset", "Select dataset"),
         value="about_panel",

--- a/dp_wizard/app/dataset_panel.py
+++ b/dp_wizard/app/dataset_panel.py
@@ -19,6 +19,9 @@ from dp_wizard.app.components.outputs import (
 from dp_wizard.utils.code_generators import make_privacy_unit_block
 
 
+dataset_panel_id = "dataset_panel"
+
+
 def dataset_ui():
     cli_info = get_cli_info()
     public_csv_placeholder = (

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,11 +23,9 @@ for_the_demo = "For the demo, we'll imagine"
 # TODO: Why is incomplete coverage reported here?
 # https://github.com/opendp/dp-wizard/issues/18
 def test_demo_app(page: Page, demo_app: ShinyAppProc):  # pragma: no cover
+    # -- Select dataset --
     page.goto(demo_app.url)
     expect(page).to_have_title("DP Wizard")
-
-    # -- Select dataset --
-    page.get_by_role("button", name="Select dataset").click()
     expect(page.get_by_text(for_the_demo)).not_to_be_visible()
     page.locator(tooltip).hover()
     expect(page.get_by_text(for_the_demo)).to_be_visible()
@@ -51,12 +49,9 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     def expect_no_error():
         expect(page.locator(".shiny-output-error")).not_to_be_attached()
 
-    # -- About --
+    # -- Select dataset --
     page.goto(default_app.url)
     expect(page).to_have_title("DP Wizard")
-
-    # -- Select dataset --
-    page.get_by_role("button", name="Select dataset").click()
     expect(page.locator(tooltip)).to_have_count(0)
     expect_visible(pick_dataset_text)
     expect_not_visible(perform_analysis_text)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,6 +25,9 @@ for_the_demo = "For the demo, we'll imagine"
 def test_demo_app(page: Page, demo_app: ShinyAppProc):  # pragma: no cover
     page.goto(demo_app.url)
     expect(page).to_have_title("DP Wizard")
+
+    # -- Select dataset --
+    page.get_by_role("button", name="Select dataset").click()
     expect(page.get_by_text(for_the_demo)).not_to_be_visible()
     page.locator(tooltip).hover()
     expect(page.get_by_text(for_the_demo)).to_be_visible()
@@ -48,9 +51,12 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     def expect_no_error():
         expect(page.locator(".shiny-output-error")).not_to_be_attached()
 
-    # -- Select dataset --
+    # -- About --
     page.goto(default_app.url)
     expect(page).to_have_title("DP Wizard")
+
+    # -- Select dataset --
+    page.get_by_role("button", name="Select dataset").click()
     expect(page.locator(tooltip)).to_have_count(0)
     expect_visible(pick_dataset_text)
     expect_not_visible(perform_analysis_text)
@@ -91,7 +97,6 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # (Note: Slider tests failed on CI when run after column details,
     # although it worked locally. This works in either environment.
     # Maybe a race condition?)
-    expect_visible("0.1")
     expect_visible("10.0")
     expect_visible("Epsilon: 1.0")
     page.locator(".irs-bar").click()
@@ -175,7 +180,7 @@ def test_default_app(page: Page, default_app: ShinyAppProc):  # pragma: no cover
     # Reports ...
 
     # ... text:
-    page.get_by_text("Reports").click()
+    page.get_by_role("button", name="Reports").click()
     with page.expect_download() as text_report_download_info:
         page.get_by_text("Download report (.txt)").click()
     expect_no_error()


### PR DESCRIPTION
- Replaces #282
- Fix #272

I would like to keep this short, and if there is important information about what this application does, then it really belongs in a README: Users shouldn't need to install to get this information.

The situation is different from DP Creator. This, at present, is a single user application, and the user found and installed it themselves. It is not embedded in a larger application.

I would strongly prefer that most users not be slowed down by this. If there's a request that this be on a splash screen on the first run, I'd prefer to tackle that as a follow-up.

About pages often do include version numbers, particularly to help users filing issues, so I've included that here as well.