### PR TITLE
Add a warning about a large number of columns

### DIFF
--- a/dp_wizard/app/analysis_panel.py
+++ b/dp_wizard/app/analysis_panel.py
@@ -11,7 +11,7 @@ from dp_wizard.utils.csv_helper import (
     read_csv_ids_names,
     get_csv_row_count,
 )
-from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip
+from dp_wizard.app.components.outputs import output_code_sample, demo_tooltip, info_box
 from dp_wizard.utils.code_generators import make_privacy_loss_block
 
 
@@ -46,6 +46,7 @@ def analysis_ui():
                     [],
                     multiple=True,
                 ),
+                ui.output_ui("columns_warning_ui"),
             ),
             ui.card(
                 ui.card_header("Privacy Budget"),
@@ -147,6 +148,17 @@ def analysis_server(
             each column has a smaller share of the privacy budget.
             """,
         )
+
+    @render.ui
+    def columns_warning_ui():
+        columns_count = len(weights())
+        if columns_count > 5:
+            return info_box(
+                """
+                Warning: With more columns, the UI will slow down
+                and the application may become unstable.
+                """
+            )
 
     @render.ui
     def simulation_card_ui():

--- a/tests/fixtures/big-fake.csv
+++ b/tests/fixtures/big-fake.csv
@@ -1,0 +1,1 @@
+A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z


### PR DESCRIPTION
- Toward #257

There might be changes at a lower level that could improve performance, but after giving it a morning, I'm not seeing any easy wins. (More notes on issue #257.) This would add a warning message if the user adds five columns, which is when performance seems to be really impacted.

- The warning itself is obscured by the selectize list; This isn't great, but I don't think there's a better place to put it: We want it near by, and I don't think we want it above. (Generally a bad idea if elements of the UI are moving around.)
- It's not a hard stop. If #256 is implemented, and there is another way to remove columns, we could disable this control when too many columns are selected... but until/if that's implemented, we don't want to disable this control, because it's the only way to remove columns.

So take this as a proposal: I'd be ok with closing this PR if it doesn't seem better than the status quo.