### PR TITLE
reactive isolate fixes infinite loop

### DIFF
--- a/dp_wizard/app/components/column_module.py
+++ b/dp_wizard/app/components/column_module.py
@@ -131,51 +131,53 @@ def column_server(
         }
         match input.analysis_type():
             case histogram.name:
-                return ui.layout_columns(
-                    [
-                        ui.input_numeric(
-                            "lower_bound",
-                            ["Lower Bound", ui.output_ui("bounds_tooltip_ui")],
-                            lower_bounds().get(name, 0),
-                            width=label_width,
-                        ),
-                        ui.input_numeric(
-                            "upper_bound",
-                            "Upper Bound",
-                            upper_bounds().get(name, 10),
-                            width=label_width,
-                        ),
-                        ui.input_numeric(
-                            "bins",
-                            ["Bin Count", ui.output_ui("bins_tooltip_ui")],
-                            bin_counts().get(name, 10),
-                            width=label_width,
-                        ),
-                        ui.output_ui("optional_weight_ui"),
-                    ],
-                    ui.output_ui("histogram_preview_ui"),
-                    col_widths=col_widths,  # type: ignore
-                )
+                with reactive.isolate():
+                    return ui.layout_columns(
+                        [
+                            ui.input_numeric(
+                                "lower_bound",
+                                ["Lower Bound", ui.output_ui("bounds_tooltip_ui")],
+                                lower_bounds().get(name, 0),
+                                width=label_width,
+                            ),
+                            ui.input_numeric(
+                                "upper_bound",
+                                "Upper Bound",
+                                upper_bounds().get(name, 10),
+                                width=label_width,
+                            ),
+                            ui.input_numeric(
+                                "bins",
+                                ["Bin Count", ui.output_ui("bins_tooltip_ui")],
+                                bin_counts().get(name, 10),
+                                width=label_width,
+                            ),
+                            ui.output_ui("optional_weight_ui"),
+                        ],
+                        ui.output_ui("histogram_preview_ui"),
+                        col_widths=col_widths,  # type: ignore
+                    )
             case mean.name:
-                return ui.layout_columns(
-                    [
-                        ui.input_numeric(
-                            "lower_bound",
-                            ["Lower", ui.output_ui("bounds_tooltip_ui")],
-                            lower_bounds().get(name, 0),
-                            width=label_width,
-                        ),
-                        ui.input_numeric(
-                            "upper_bound",
-                            "Upper",
-                            upper_bounds().get(name, 10),
-                            width=label_width,
-                        ),
-                        ui.output_ui("optional_weight_ui"),
-                    ],
-                    ui.output_ui("mean_preview_ui"),
-                    col_widths=col_widths,  # type: ignore
-                )
+                with reactive.isolate():
+                    return ui.layout_columns(
+                        [
+                            ui.input_numeric(
+                                "lower_bound",
+                                ["Lower", ui.output_ui("bounds_tooltip_ui")],
+                                lower_bounds().get(name, 0),
+                                width=label_width,
+                            ),
+                            ui.input_numeric(
+                                "upper_bound",
+                                "Upper",
+                                upper_bounds().get(name, 10),
+                                width=label_width,
+                            ),
+                            ui.output_ui("optional_weight_ui"),
+                        ],
+                        ui.output_ui("mean_preview_ui"),
+                        col_widths=col_widths,  # type: ignore
+                    )
 
     @render.ui
     def bounds_tooltip_ui():


### PR DESCRIPTION
- Fix #306

If we just see a change in the reactive values, we _should not_ redraw the inputs.

(Turn on "ignore whitespace in diff" in github to make the review easier).

I went down a little dead end before remembering this method: It's not clear to me that the increment/decrement buttons are actually a good thing, or that the plots should rerender on every keypress. A separate PR addresses that, but doesn't really fix the bug:

- #310
