### PR TITLE
No silent errors for code gen

### DIFF
--- a/dp_wizard/app/results_panel.py
+++ b/dp_wizard/app/results_panel.py
@@ -108,7 +108,7 @@ def results_ui():
     )
 
 
-def generate_code_or_modal_error(download_generator) -> str:
+def make_download_or_modal_error(download_generator) -> str:  # pragma: no cover
     try:
         with ui.Progress() as progress:
             progress.set(message=wait_message)
@@ -197,61 +197,49 @@ def results_server(
         media_type="text/x-python",
     )
     async def download_script():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield ScriptGenerator(analysis_plan()).make_py()
+        yield make_download_or_modal_error(ScriptGenerator(analysis_plan()).make_py)
 
     @render.download(
         filename="dp-wizard-notebook.ipynb",
         media_type="application/x-ipynb+json",
     )
     async def download_notebook():
-        yield generate_code_or_modal_error(notebook_nb)
+        yield make_download_or_modal_error(notebook_nb)
 
     @render.download(
         filename="dp-wizard-notebook-unexecuted.ipynb",
         media_type="application/x-ipynb+json",
     )
     async def download_notebook_unexecuted():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_nb_unexecuted()
+        yield make_download_or_modal_error(notebook_nb_unexecuted)
 
     @render.download(  # pyright: ignore
         filename="dp-wizard-notebook.html",
         media_type="text/html",
     )
     async def download_html():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_html()
+        yield make_download_or_modal_error(notebook_html)
 
     @render.download(  # pyright: ignore
         filename="dp-wizard-notebook-unexecuted.html",
         media_type="text/html",
     )
     async def download_html_unexecuted():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_html_unexecuted()
+        yield make_download_or_modal_error(notebook_html_unexecuted)
 
     @render.download(
         filename="dp-wizard-notebook.pdf",
         media_type="application/pdf",
     )  # pyright: ignore
     async def download_pdf():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_pdf()
+        yield make_download_or_modal_error(notebook_pdf)
 
     @render.download(
         filename="dp-wizard-notebook.pdf",
         media_type="application/pdf",
     )  # pyright: ignore
     async def download_pdf_unexecuted():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_pdf_unexecuted()
+        yield make_download_or_modal_error(notebook_pdf_unexecuted)
 
     @render.download(
         filename="dp-wizard-report.txt",

--- a/dp_wizard/app/results_panel.py
+++ b/dp_wizard/app/results_panel.py
@@ -186,14 +186,18 @@ def results_server(
             progress.set(message=wait_message)
             yield ScriptGenerator(analysis_plan()).make_py()
 
-    @render.download(
-        filename="dp-wizard-notebook.ipynb",
-        media_type="application/x-ipynb+json",
-    )
     async def download_notebook():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
-            yield notebook_nb()
+        try:
+            with ui.Progress() as progress:
+                progress.set(message=wait_message)
+                yield notebook_nb()
+        except Exception as e:
+            modal = ui.modal(
+                ui.pre(str(e)),
+                title="Error generating code",
+                easy_close=True,
+            )
+            ui.modal_show(modal)
 
     @render.download(
         filename="dp-wizard-notebook-unexecuted.ipynb",

--- a/dp_wizard/app/results_panel.py
+++ b/dp_wizard/app/results_panel.py
@@ -246,23 +246,19 @@ def results_server(
         media_type="text/plain",
     )
     async def download_report():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
+        def make_report():
             notebook_nb()  # Evaluate just for the side effect of creating report.
-            report_txt = (
-                Path(__file__).parent.parent / "tmp" / "report.txt"
-            ).read_text()
-            yield report_txt
+            return (Path(__file__).parent.parent / "tmp" / "report.txt").read_text()
+
+        yield make_download_or_modal_error(make_report)
 
     @render.download(
         filename="dp-wizard-report.csv",
         media_type="text/plain",
     )
     async def download_table():
-        with ui.Progress() as progress:
-            progress.set(message=wait_message)
+        def make_table():
             notebook_nb()  # Evaluate just for the side effect of creating report.
-            report_csv = (
-                Path(__file__).parent.parent / "tmp" / "report.csv"
-            ).read_text()
-            yield report_csv
+            return (Path(__file__).parent.parent / "tmp" / "report.csv").read_text()
+
+        yield make_download_or_modal_error(make_table)

--- a/dp_wizard/utils/code_generators/no-tests/_notebook.py
+++ b/dp_wizard/utils/code_generators/no-tests/_notebook.py
@@ -11,8 +11,6 @@
 # -
 
 # +
-1 / 0
-
 IMPORTS_BLOCK
 # -
 

--- a/dp_wizard/utils/code_generators/no-tests/_notebook.py
+++ b/dp_wizard/utils/code_generators/no-tests/_notebook.py
@@ -11,6 +11,8 @@
 # -
 
 # +
+1 / 0
+
 IMPORTS_BLOCK
 # -
 

--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -5,7 +5,6 @@ import subprocess
 import json
 import nbformat
 import nbconvert
-from warnings import warn
 import jupytext
 
 

--- a/dp_wizard/utils/converters.py
+++ b/dp_wizard/utils/converters.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from dataclasses import dataclass
 import subprocess
 import json
 import nbformat
@@ -15,6 +16,15 @@ def _is_kernel_installed() -> bool:
         return True
     except ValueError:  # pragma: no cover
         return False
+
+
+@dataclass(frozen=True)
+class ConversionException(Exception):
+    command: str
+    stderr: str
+
+    def __str__(self):
+        return f"Script to notebook conversion failed: {self.command}\n{self.stderr})"
 
 
 def convert_py_to_nb(python_str: str, execute: bool = False):
@@ -40,7 +50,6 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
         argv.append(str(py_path.absolute()))  # type: ignore
         result = subprocess.run(argv, text=True, capture_output=True)
         if result.returncode != 0:
-            warn(result.stderr)
             # If there is an error, we want a copy of the file that will stay around,
             # outside the "with TemporaryDirectory()" block.
             # The command we show in the error message isn't exactly what was run,
@@ -49,7 +58,7 @@ def convert_py_to_nb(python_str: str, execute: bool = False):
             debug_path.write_text(python_str)
             argv.pop()
             argv.append(str(debug_path))  # type: ignore
-            raise Exception(f"Script to notebook conversion failed: {' '.join(argv)}")
+            raise ConversionException(command=" ".join(argv), stderr=result.stderr)
         return _clean_nb(result.stdout.strip())
 
 

--- a/tests/utils/test_converters.py
+++ b/tests/utils/test_converters.py
@@ -7,6 +7,7 @@ from dp_wizard.utils.converters import (
     _clean_nb,
     convert_nb_to_html,
     convert_nb_to_pdf,
+    ConversionException,
 )
 
 
@@ -58,18 +59,12 @@ def test_clean_nb():
 def test_convert_py_to_nb_error():
     python_str = "Invalid python!"
     with pytest.raises(
-        Exception,
-        match=(
-            r"Script to notebook conversion failed: "
-            r"jupytext --from \.py --to \.ipynb "
-            r"--output - --execute /tmp/script\.py"
-        ),
+        ConversionException,
+        # There's more, but what's most important is that
+        # the line with the error shows up in the message.
+        match=(r"Invalid python!"),
     ):
-        with pytest.warns(
-            UserWarning,
-            match=r"SyntaxError.*invalid syntax",
-        ):
-            convert_py_to_nb(python_str, execute=True)
+        convert_py_to_nb(python_str, execute=True)
 
 
 def test_convert_nb_to_html():


### PR DESCRIPTION
- Fix #305

Code review is sufficient, but if you'd like to see the modal, try adding an error at the top of `_notebook.py`. 

Shiny doesn't offer component level testing, and since the app if it's working correctly never hits this code, it's not easy to execute in an end-to-end test. If we need to do that, the solution might be adding functionality which is hidden from the user, or making a mini application just to exercise this.

I don't think that's necessary right now, but that might not be the right call. Could also file an issue and come back to this later.