### PR TITLE
Specify the minimum python version in readme

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -1,13 +1,28 @@
 # DP Wizard
 
+[![pypi](https://img.shields.io/pypi/v/dp_wizard)](https://pypi.org/project/dp_wizard/)
+
+Building on what we've learned from [DP Creator](https://github.com/opendp/dpcreator), DP Wizard offers:
+
+- Easy installation with `pip install dp_wizard`
+- Simplified single-user application design
+- Streamlined workflow that doesn't assume familiarity with differential privacy
+- Interactive visualization of privacy budget choices
+- UI development in Python with [Shiny](https://shiny.posit.co/py/)
+
 DP Wizard guides the user through the application of differential privacy.
 After selecting a local CSV, users are prompted to describe the analysis they need.
 Output options include:
+
 - A Jupyter notebook which demonstrates how to use [OpenDP](https://docs.opendp.org/).
 - A plain Python script.
 - Text and CSV reports.
 
 ## Usage
+
+DP Wizard requires Python 3.10 or later.
+You can check your current version with `python --version`.
+The exact upgrade process will depend on your environment and operating system.
 
 ```
 usage: dp-wizard [-h] [--public_csv CSV] [--private_csv CSV] [--contrib CONTRIB] [--demo]
@@ -34,7 +49,3 @@ with the same structure. Perhaps the public CSV is older and no longer
 sensitive. Preview visualizations will be made with the public data,
 but the release will be made with private data.
 ```
-
-## Contributions
-
-We welcome contributions from the community. More info is on the [main project page](https://github.com/opendp/dp-wizard?tab=readme-ov-file#contributions).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ Building on what we've learned from [DP Creator](https://github.com/opendp/dpcre
 - Interactive visualization of privacy budget choices
 - UI development in Python with [Shiny](https://shiny.posit.co/py/)
 
+DP Wizard guides the user through the application of differential privacy.
+After selecting a local CSV, users are prompted to describe the analysis they need.
+Output options include:
+
+- A Jupyter notebook which demonstrates how to use [OpenDP](https://docs.opendp.org/).
+- A plain Python script.
+- Text and CSV reports.
+
 ## Usage
+
+DP Wizard requires Python 3.10 or later.
+You can check your current version with `python --version`.
+The exact upgrade process will depend on your environment and operating system.
 
 ```
 usage: dp-wizard [-h] [--public_csv CSV] [--private_csv CSV] [--contrib CONTRIB] [--demo]
@@ -57,7 +69,7 @@ so let's remember [what we learned](WHAT-WE-LEARNED.md) along the way.
 
 ### Getting Started
 
-DP-Wizard will run across multiple versions, but for the fewest surprises during development, it makes sense to use the oldest supported version in a virtual environment. On MacOS:
+DP-Wizard will run across multiple Python versions, but for the fewest surprises during development, it makes sense to use the oldest supported version in a virtual environment. On MacOS:
 ```shell
 $ git clone https://github.com/opendp/dp-wizard.git
 $ cd dp-wizard

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -37,3 +37,20 @@ def test_opendp_pin(rel_path):
     ]
     assert len(opendp_lines) == 1
     assert "opendp[polars]==0.12.1a20250227001" in opendp_lines[0]
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    [
+        "README.md",
+        "README-PYPI.md",
+        ".github/workflows/test.yml",
+    ],
+)
+def test_python_min_version(rel_path):
+    root = Path(__file__).parent.parent
+    text = (root / rel_path).read_text()
+    assert "3.10" in text
+    if "README" in rel_path:
+        # Make sure we haven't upgraded one reference by mistake.
+        assert not re.search(r"3.1[^0]", text)

--- a/tests/utils/test_argparse_helpers.py
+++ b/tests/utils/test_argparse_helpers.py
@@ -10,29 +10,6 @@ from dp_wizard.utils.argparse_helpers import _get_arg_parser, _existing_csv_type
 fixtures_path = Path(__file__).parent.parent / "fixtures"
 
 
-def extract_block(md):
-    '''
-    >>> fake_md = """
-    ... header
-    ... ```
-    ... block
-    ... ```
-    ... footer
-    ... """
-    >>> extract_block(fake_md)
-    'block'
-
-    >>> extract_block('sorry')
-    Traceback (most recent call last):
-    ...
-    Exception: no match for block
-    '''
-    match = re.search(r"```\n(.*?)\n```", md, flags=re.DOTALL)
-    if match:
-        return match.group(1)
-    raise Exception("no match for block")
-
-
 def test_help():
     help = re.sub(
         # line wrapping of params varies:
@@ -50,11 +27,11 @@ def test_help():
 
     root_path = Path(__file__).parent.parent.parent
 
-    readme_md = (root_path / "README.md").read_text()
-    assert help == extract_block(readme_md)
-
     readme_pypi_md = (root_path / "README-PYPI.md").read_text()
-    assert help == extract_block(readme_pypi_md)
+    assert help in readme_pypi_md
+
+    readme_md = (root_path / "README.md").read_text()
+    assert readme_pypi_md in readme_md
 
 
 def test_arg_validation_no_file():


### PR DESCRIPTION
- Fix #330
- Add test to make sure we're in sync.
- Make README-PYPI a strict subset of README: Even having two separate files is a little gratuitous, but let's keep this relatively simple.
- Remove test helper function that is not needed.