### PR TITLE
Test both pinned and unpinned deps in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ jobs:
       matrix:
         python-version:
           - '3.10'
-          - '3.11'
-          - '3.12'
           - '3.13'
+        requirements-file:
+          - 'requirements-dev.txt' # pinned, for predictability
+          - 'requirements-dev.in' # un-pinned, so we catch problems early
 
     steps:
       - name: Checkout repository
@@ -32,12 +33,8 @@ jobs:
       - name: Install package
         run: flit install
 
-      - name: Check CLI
-        # TODO: This won't catch most missing dependencies.
-        run: dp-wizard --help
-
       - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r ${{ matrix.requirements-file }}
 
       - name: Install browsers
         # Install just one browser instead of the default three.


### PR DESCRIPTION
- Fix #329

(The required checks for a repo are in the github configuration, not in the source, so this PR thinks it has tests that haven't run; If it passes review, I'll merge and update the configuration.)