### PR TITLE
Add webpdf extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "opendp[polars]==0.12.1a20250227001",
     "jupytext",
     "jupyter-client",
-    "nbconvert",
+    "nbconvert[webpdf]",
     "ipykernel",
     "black",
     "pyyaml",


### PR DESCRIPTION
- Fix #359

My guess is that playwright's dependencies overlap with this, so when tests are run we don't notice that anything is missing.