### PR TITLE
Set lower bound on dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,16 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = [
-    "shiny",
-    "faicons",
-    "matplotlib",
+    "shiny>=1.2.1",
+    "faicons>=0.2.2",
+    "matplotlib>=3.10.1",
     "opendp[polars]==0.12.1a20250227001",
-    "jupytext",
-    "jupyter-client",
-    "nbconvert[webpdf]",
-    "ipykernel",
-    "black",
-    "pyyaml",
+    "jupytext>=1.16.7",
+    "jupyter-client>=8.6.3",
+    "nbconvert[webpdf]>=7.16.6",
+    "ipykernel>=6.29.5",
+    "black>=25.1.0",
+    "pyyaml>=6.0.2",
 ]
 
 [project.scripts]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -19,23 +19,25 @@ flake8-bugbear
 
 
 # Everything below should also be listed in pyproject.toml:
+# (It may be possible to lower these bounds,
+# but for now take the versions specified in requirements-dev.txt)
 
 # OpenDP:
 opendp[polars]==0.12.1a20250227001
 
 # Conversion:
-black
-jupytext
-jupyter-client
-pyyaml
-nbconvert
-ipykernel
+black>=25.1.0
+jupytext>=1.16.7
+jupyter-client>=8.6.3
+pyyaml>=6.0.2
+nbconvert[webpdf]>=7.16.6
+ipykernel>=6.29.5
 # May also require:
 # python -m ipykernel install --name kernel_name --user
 
 # Shiny:
-shiny
-faicons
+shiny>=1.2.1
+faicons>=0.2.2
 
 # Visualization:
-matplotlib
+matplotlib>=3.10.1

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,17 +4,18 @@
 # Developer tools:
 pip-tools
 flit
-black
-flake8
-flake8-bugbear
 pre-commit
 
 # Testing:
 pytest
 pytest-playwright
-pyright
 pytest-cov
 pytest-xdist
+
+# Linting and type checking:
+pyright
+flake8
+flake8-bugbear
 
 
 # Everything below should also be listed in pyproject.toml:
@@ -23,6 +24,7 @@ pytest-xdist
 opendp[polars]==0.12.1a20250227001
 
 # Conversion:
+black
 jupytext
 jupyter-client
 pyyaml


### PR DESCRIPTION
- Fix #361 
- prompted by #357

This is not the lowest possible bound, but it does lessen the chance of picking up an old-old-old version of a dependency from the environment.

See also:
- #356 (gives us some coverage of the low and high end of dependency versions, as well as the low and high python versions)
- #60 