### PR TITLE
config -> expr

### DIFF
--- a/dp_wizard/utils/code_generators/abstract_generator.py
+++ b/dp_wizard/utils/code_generators/abstract_generator.py
@@ -159,7 +159,7 @@ class AbstractGenerator(ABC):
         )
         extra_columns = ", ".join(
             [
-                f"{name_to_identifier(name)}_bin_config"
+                f"{name_to_identifier(name)}_bin_expr"
                 for name, plan in self.columns.items()
                 if get_analysis_by_name(plan.analysis_type).has_bins()
             ]

--- a/dp_wizard/utils/code_generators/analyses/histogram/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/histogram/__init__.py
@@ -60,10 +60,10 @@ def make_column_config_block(column_name, lower_bound, upper_bound, bin_count):
 
     snake_name = snake_case(column_name)
     return (
-        Template("histogram_config", __file__)
+        Template("histogram_expr", __file__)
         .fill_expressions(
             CUT_LIST_NAME=f"{snake_name}_cut_points",
-            BIN_CONFIG_NAME=f"{snake_name}_bin_config",
+            BIN_EXPR_NAME=f"{snake_name}_bin_expr",
         )
         .fill_values(
             LOWER_BOUND=lower_bound,

--- a/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_expr.py
+++ b/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_expr.py
@@ -6,7 +6,7 @@ CUT_LIST_NAME = make_cut_points(
 )
 
 # Use these cut points to add a new binned column to the table:
-BIN_CONFIG_NAME = (
+BIN_EXPR_NAME = (
     pl.col(COLUMN_NAME)
     .cut(CUT_LIST_NAME)
     .alias(BIN_COLUMN_NAME)  # Give the new column a name.

--- a/dp_wizard/utils/code_generators/analyses/mean/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/mean/__init__.py
@@ -17,7 +17,7 @@ def make_query(code_gen, identifier, accuracy_name, stats_name):
         .fill_expressions(
             QUERY_NAME=f"{identifier}_query",
             STATS_NAME=stats_name,
-            CONFIG_NAME=f"{identifier}_config",
+            EXPR_NAME=f"{identifier}_expr",
         )
         .finish()
     )
@@ -52,9 +52,9 @@ def make_column_config_block(column_name, lower_bound, upper_bound, bin_count):
 
     snake_name = snake_case(column_name)
     return (
-        Template("mean_config", __file__)
+        Template("mean_expr", __file__)
         .fill_expressions(
-            CONFIG_NAME=f"{snake_name}_config",
+            EXPR_NAME=f"{snake_name}_expr",
         )
         .fill_values(
             COLUMN_NAME=column_name,

--- a/dp_wizard/utils/code_generators/analyses/mean/no-tests/_mean_expr.py
+++ b/dp_wizard/utils/code_generators/analyses/mean/no-tests/_mean_expr.py
@@ -1,4 +1,4 @@
-CONFIG_NAME = (
+EXPR_NAME = (
     pl.col(COLUMN_NAME)
     .cast(float)
     .fill_nan(0)

--- a/dp_wizard/utils/code_generators/analyses/mean/no-tests/_mean_query.py
+++ b/dp_wizard/utils/code_generators/analyses/mean/no-tests/_mean_query.py
@@ -1,8 +1,8 @@
 groups = GROUP_NAMES
 QUERY_NAME = (
-    context.query().group_by(groups).agg(CONFIG_NAME)
+    context.query().group_by(groups).agg(EXPR_NAME)
     if groups
-    else context.query().select(CONFIG_NAME)
+    else context.query().select(EXPR_NAME)
 )
 STATS_NAME = QUERY_NAME.release().collect()
 STATS_NAME

--- a/dp_wizard/utils/code_generators/analyses/median/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/median/__init__.py
@@ -17,7 +17,7 @@ def make_query(code_gen, identifier, accuracy_name, stats_name):
         .fill_expressions(
             QUERY_NAME=f"{identifier}_query",
             STATS_NAME=stats_name,
-            CONFIG_NAME=f"{identifier}_config",
+            EXPR_NAME=f"{identifier}_expr",
         )
         .finish()
     )
@@ -44,9 +44,9 @@ def make_column_config_block(column_name, lower_bound, upper_bound, bin_count):
 
     snake_name = snake_case(column_name)
     return (
-        Template("median_config", __file__)
+        Template("median_expr", __file__)
         .fill_expressions(
-            CONFIG_NAME=f"{snake_name}_config",
+            EXPR_NAME=f"{snake_name}_expr",
         )
         .fill_values(
             COLUMN_NAME=column_name,

--- a/dp_wizard/utils/code_generators/analyses/median/no-tests/_median_expr.py
+++ b/dp_wizard/utils/code_generators/analyses/median/no-tests/_median_expr.py
@@ -1,4 +1,4 @@
-CONFIG_NAME = (
+EXPR_NAME = (
     pl.col(COLUMN_NAME)
     .cast(float)
     .fill_nan(0)

--- a/dp_wizard/utils/code_generators/analyses/median/no-tests/_median_query.py
+++ b/dp_wizard/utils/code_generators/analyses/median/no-tests/_median_query.py
@@ -1,8 +1,8 @@
 groups = GROUP_NAMES
 QUERY_NAME = (
-    context.query().group_by(groups).agg(CONFIG_NAME)
+    context.query().group_by(groups).agg(EXPR_NAME)
     if groups
-    else context.query().select(CONFIG_NAME)
+    else context.query().select(EXPR_NAME)
 )
 STATS_NAME = QUERY_NAME.release().collect()
 STATS_NAME

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -34,7 +34,7 @@ def test_make_column_config_block_for_mean():
             upper_bound=100,
             bin_count=10,
         ).strip()
-        == """hw_grade_config = (
+        == """hw_grade_expr = (
     pl.col('HW GRADE')
     .cast(float)
     .fill_nan(0)
@@ -53,7 +53,7 @@ def test_make_column_config_block_for_median():
             upper_bound=100,
             bin_count=10,
         ).strip()
-        == """hw_grade_config = (
+        == """hw_grade_expr = (
     pl.col('HW GRADE')
     .cast(float)
     .fill_nan(0)
@@ -83,7 +83,7 @@ hw_grade_cut_points = make_cut_points(
 )
 
 # Use these cut points to add a new binned column to the table:
-hw_grade_bin_config = (
+hw_grade_bin_expr = (
     pl.col('HW GRADE')
     .cut(hw_grade_cut_points)
     .alias('hw_grade_bin')  # Give the new column a name.


### PR DESCRIPTION
- Fix #316

Calling it "config" to begin with was a mistake on my part. These are [polars expressions](https://docs.pola.rs/api/python/dev/reference/expressions/index.html), and `expr` is used consistently in our documentation.