### PR TITLE
click outside error modal or hit esc to close

### DIFF
--- a/dp_wizard/app/results_panel.py
+++ b/dp_wizard/app/results_panel.py
@@ -125,6 +125,7 @@ def make_download_or_modal_error(download_generator) -> str:  # pragma: no cover
             ui.pre(str(e)),
             title="Error generating code",
             size="xl",
+            easy_close=True,
         )
         ui.modal_show(modal)
         raise types.SilentException("code generation")


### PR DESCRIPTION
- Fix #380

(If you want to actually exercise this, you'll need to introduce an error in the notebook, like a `0/0` at the top of `_notebook.py`, though I'm not sure you need to be that diligent.)