### PR TITLE
always show epsilon slider endpoints

### DIFF
--- a/dp_wizard/app/components/inputs.py
+++ b/dp_wizard/app/components/inputs.py
@@ -16,21 +16,25 @@ def log_slider(id: str, lower_bound: float, upper_bound: float):
             f"""
 <style>
 .irs:has(+ #{id}) .irs-single {{
+    /* Hide the current, non-log value. */
     visibility: hidden;
 }}
+.irs:has(+ #{id}) .irs-min, .irs:has(+ #{id}) .irs-max {{
+    /* Always show the endpoint values. */
+    visibility: visible !important;
+}}
 
-.irs:has(+ #{id}) .irs-min {{
+.irs:has(+ #{id}) .irs-min, .irs:has(+ #{id}) .irs-max {{
+    /* Shrink the non-log endpoint values to invisibility... */
     font-size: 0;
 }}
 .irs:has(+ #{id}) .irs-min::before {{
+    /* ... and instead show lower ... */
     content: "{lower_bound}";
     font-size: 12px;
 }}
-
-.irs:has(+ #{id}) .irs-max {{
-    font-size: 0;
-}}
 .irs:has(+ #{id}) .irs-max::after {{
+    /* ... and upper bounds. */
     content: "{upper_bound}";
     font-size: 12px;
 }}


### PR DESCRIPTION
- Fix #385

(In defense of the off-the-shelf widget, the end values are being hidden because there should be another box containing the current value over the slider, and when they would overlap, the endpoints are suppressed. At some point, it might be better to actually make a log scaled slider, instead of CSS hacking the linear scale.)