### PR TITLE
fallback to 0.0 if unexpected key

### DIFF
--- a/dp_wizard/utils/shared.py
+++ b/dp_wizard/utils/shared.py
@@ -22,10 +22,15 @@ def interval_bottom(interval: str):
     10.0
     >>> interval_bottom("-10")
     -10.0
+    >>> interval_bottom("unexpected")
+    0.0
     """
     # Intervals from Polars are always open on the left,
     # so that's the only case we cover with replace().
-    return float(interval.split(",")[0].replace("(", ""))
+    try:
+        return float(interval.split(",")[0].replace("(", ""))
+    except ValueError:
+        return 0.0
 
 
 def df_to_columns(df: DataFrame):


### PR DESCRIPTION
- Fix #367

Mike's suspicion that empty values where we expected numbers in this CSV caused problems is correct, but the error in this case is shallow: This is a helper function that is used to sort the data before plotting. Falling back to 0 is fine.

Exercising the application against badly behaved CSVs is still a todo, but for this particular bug, this fix seems like enough.