### PR TITLE
Fix `type` in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-back.md
+++ b/.github/ISSUE_TEMPLATE/bug-back.md
@@ -4,8 +4,7 @@ about: There's an error downloading the results, or the results are incorrect.
 title: ''
 labels:
     - 'req: OpenDP API'
-types:
-    - 'Bug'
+type: 'Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug-front.md
+++ b/.github/ISSUE_TEMPLATE/bug-front.md
@@ -4,8 +4,7 @@ about: The interface isn't working correctly, before downloading results.
 title: ''
 labels:
     - 'req: Python Shiny'
-types:
-    - 'Bug'
+type: 'Bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,8 +2,7 @@
 name: Feature
 about: New functionality
 title: ''
-types:
-    - 'Feature'
+type: 'Feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,8 +4,7 @@ about: Ask about intended behavior, our development roadmap, or anything.
 title: ''
 labels:
     - 'question'
-types:
-    - 'Task'
+type: 'Task'
 assignees: ''
 
 ---

--- a/tests/fixtures/string.csv
+++ b/tests/fixtures/string.csv
@@ -1,2 +1,0 @@
-string
-string

--- a/tests/fixtures/string.csv
+++ b/tests/fixtures/string.csv
@@ -1,0 +1,2 @@
+string
+string


### PR DESCRIPTION
- Fix #401

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

> - type
> - The issue type that will be automatically added to issues created with this template. Issue types are defined at the organization level and can be used to create a shared syntax across repos.
> - Optional
> - String