### PR TITLE
Show warnings if you jump around tabs

### DIFF
--- a/dp_wizard/shiny/__init__.py
+++ b/dp_wizard/shiny/__init__.py
@@ -111,6 +111,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
         groups = reactive.value([])
         weights = reactive.value({})
         epsilon = reactive.value(1.0)
+        released = reactive.value(False)
 
         about_panel.about_server(
             input,
@@ -121,6 +122,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
             input,
             output,
             session,
+            released=released,
             is_demo=cli_info.is_demo,
             in_cloud=cli_info.in_cloud,
             initial_public_csv_path="",
@@ -134,6 +136,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
             input,
             output,
             session,
+            released=released,
             is_demo=cli_info.is_demo,
             public_csv_path=public_csv_path,
             column_names=column_names,
@@ -150,6 +153,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
             input,
             output,
             session,
+            released=released,
             in_cloud=cli_info.in_cloud,
             public_csv_path=public_csv_path,
             private_csv_path=private_csv_path,

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -25,6 +25,7 @@ from dp_wizard.utils.code_generators import make_privacy_loss_block
 def analysis_ui():
     return ui.nav_panel(
         "Define Analysis",
+        ui.output_ui("analysis_requirements_warning_ui"),
         ui.output_ui("analysis_release_warning_ui"),
         ui.layout_columns(
             ui.card(
@@ -141,6 +142,18 @@ def analysis_server(
         group_ids_selected = input.groups_selectize()
         column_ids_to_names = csv_ids_names_calc()
         groups.set([column_ids_to_names[id] for id in group_ids_selected])
+
+    @render.ui
+    def analysis_requirements_warning_ui():
+        return hide_if(
+            bool(column_names()),
+            info_md_box(
+                """
+                Please select your dataset on the previous tab
+                before defining your analysis.
+                """
+            ),
+        )
 
     @render.ui
     def analysis_release_warning_ui():

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -16,6 +16,8 @@ from dp_wizard.shiny.components.outputs import (
     output_code_sample,
     demo_tooltip,
     nav_button,
+    hide_if,
+    info_md_box,
 )
 from dp_wizard.utils.code_generators import make_privacy_loss_block
 
@@ -23,6 +25,7 @@ from dp_wizard.utils.code_generators import make_privacy_loss_block
 def analysis_ui():
     return ui.nav_panel(
         "Define Analysis",
+        ui.output_ui("analysis_release_warning_ui"),
         ui.layout_columns(
             ui.card(
                 ui.card_header("Grouping"),
@@ -99,6 +102,7 @@ def analysis_server(
     input: Inputs,
     output: Outputs,
     session: Session,
+    released: reactive.Value[bool],
     public_csv_path: reactive.Value[str],
     # private_csv_path is not needed, since we have the column_names.
     column_names: reactive.Value[list[str]],
@@ -137,6 +141,19 @@ def analysis_server(
         group_ids_selected = input.groups_selectize()
         column_ids_to_names = csv_ids_names_calc()
         groups.set([column_ids_to_names[id] for id in group_ids_selected])
+
+    @render.ui
+    def analysis_release_warning_ui():
+        return hide_if(
+            not released(),
+            info_md_box(
+                """
+            After making a differentially private release,
+            any changes will constitute a new release,
+            and an additional epsilon spend.
+            """
+            ),
+        )
 
     @reactive.effect
     @reactive.event(input.columns_selectize)

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -148,10 +148,10 @@ def analysis_server(
             not released(),
             info_md_box(
                 """
-            After making a differentially private release,
-            any changes will constitute a new release,
-            and an additional epsilon spend.
-            """
+                After making a differentially private release,
+                changes to the analysis will constitute a new release,
+                and an additional epsilon spend.
+                """
             ),
         )
 

--- a/dp_wizard/shiny/dataset_panel.py
+++ b/dp_wizard/shiny/dataset_panel.py
@@ -102,10 +102,10 @@ def dataset_server(
             not released(),
             info_md_box(
                 """
-            After making a differentially private release,
-            any changes will constitute a new release,
-            and an additional epsilon spend.
-            """
+                After making a differentially private release,
+                changes to the dataset will constitute a new release,
+                and an additional epsilon spend.
+                """
             ),
         )
 

--- a/dp_wizard/shiny/dataset_panel.py
+++ b/dp_wizard/shiny/dataset_panel.py
@@ -26,6 +26,7 @@ dataset_panel_id = "dataset_panel"
 def dataset_ui():
     return ui.nav_panel(
         "Select Dataset",
+        ui.output_ui("dataset_release_warning_ui"),
         ui.output_ui("csv_or_columns_ui"),
         ui.card(
             ui.card_header("Unit of privacy"),
@@ -49,6 +50,7 @@ def dataset_server(
     input: Inputs,
     output: Outputs,
     session: Session,
+    released: reactive.Value[bool],
     is_demo: bool,
     in_cloud: bool,
     initial_public_csv_path: str,
@@ -93,6 +95,19 @@ def dataset_server(
             )
             if just_public or just_private:
                 return just_public, just_private
+
+    @render.ui
+    def dataset_release_warning_ui():
+        return hide_if(
+            not released(),
+            info_md_box(
+                """
+            After making a differentially private release,
+            any changes will constitute a new release,
+            and an additional epsilon spend.
+            """
+            ),
+        )
 
     @render.ui
     def csv_or_columns_ui():

--- a/dp_wizard/shiny/results_panel.py
+++ b/dp_wizard/shiny/results_panel.py
@@ -61,6 +61,7 @@ def results_server(
     input: Inputs,
     output: Outputs,
     session: Session,
+    released: reactive.Value[bool],
     in_cloud: bool,
     public_csv_path: reactive.Value[str],
     private_csv_path: reactive.Value[str],
@@ -209,6 +210,7 @@ def results_server(
         # and drops reports in the tmp dir.
         # Could be slow!
         # Luckily, reactive calcs are lazy.
+        released.set(True)
         notebook_py = NotebookGenerator(analysis_plan()).make_py()
         return convert_py_to_nb(notebook_py, execute=True)
 

--- a/dp_wizard/shiny/results_panel.py
+++ b/dp_wizard/shiny/results_panel.py
@@ -15,6 +15,10 @@ from dp_wizard.utils.converters import (
     convert_py_to_nb,
     convert_nb_to_html,
 )
+from dp_wizard.shiny.components.outputs import (
+    hide_if,
+    info_md_box,
+)
 
 
 wait_message = "Please wait."
@@ -51,6 +55,7 @@ def make_download_or_modal_error(download_generator):  # pragma: no cover
 def results_ui():  # pragma: no cover
     return ui.nav_panel(
         "Download Results",
+        ui.output_ui("results_requirements_warning_ui"),
         ui.output_ui("download_results_ui"),
         ui.output_ui("download_code_ui"),
         value="results_panel",
@@ -74,6 +79,19 @@ def results_server(
     weights: reactive.Value[dict[str, str]],
     epsilon: reactive.Value[float],
 ):  # pragma: no cover
+
+    @render.ui
+    def results_requirements_warning_ui():
+        return hide_if(
+            bool(weights()),
+            info_md_box(
+                """
+                Please define your analysis on the previous tab
+                before downloading results.
+                """
+            ),
+        )
+
     @render.ui
     def download_results_ui():
         if in_cloud:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,13 +167,19 @@ def test_default_app_validations(
 def test_default_app_downloads(
     page: Page, default_app: ShinyAppProc
 ):  # pragma: no cover
+
+    dataset_release_warning = "changes to the dataset will constitute a new release"
+    analysis_release_warning = "changes to the analysis will constitute a new release"
+
     # -- Select dataset --
     page.goto(default_app.url)
+    expect(page.get_by_text(dataset_release_warning)).not_to_be_visible()
     csv_path = Path(__file__).parent / "fixtures" / "fake.csv"
     page.get_by_label("Choose Public CSV").set_input_files(csv_path.resolve())
 
     # -- Define analysis --
     page.get_by_role("button", name="Define analysis").click()
+    expect(page.get_by_text(analysis_release_warning)).not_to_be_visible()
 
     # Pick grouping:
     page.locator(".selectize-input").nth(0).click()
@@ -214,3 +220,11 @@ def test_default_app_downloads(
         download = download_info.value
         content = download.path().read_bytes()
         assert content  # Could add assertions for different document types.
+
+    # -- Define analysis --
+    page.get_by_role("tab", name="Define Analysis").click()
+    expect(page.get_by_text(analysis_release_warning)).to_be_visible()
+
+    # -- Download Results --
+    page.get_by_role("tab", name="Select Dataset").click()
+    expect(page.get_by_text(dataset_release_warning)).to_be_visible()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -170,16 +170,25 @@ def test_default_app_downloads(
 
     dataset_release_warning = "changes to the dataset will constitute a new release"
     analysis_release_warning = "changes to the analysis will constitute a new release"
+    analysis_requirements_warning = "select your dataset on the previous tab"
+    results_requirements_warning = "define your analysis on the previous tab"
 
-    # -- Select dataset --
     page.goto(default_app.url)
     expect(page.get_by_text(dataset_release_warning)).not_to_be_visible()
+    page.get_by_role("tab", name="Define Analysis").click()
+    expect(page.get_by_text(analysis_requirements_warning)).to_be_visible()
+    page.get_by_role("tab", name="Download Results").click()
+    expect(page.get_by_text(results_requirements_warning)).to_be_visible()
+    page.get_by_role("tab", name="Select Dataset").click()
+
+    # -- Select dataset --
     csv_path = Path(__file__).parent / "fixtures" / "fake.csv"
     page.get_by_label("Choose Public CSV").set_input_files(csv_path.resolve())
 
     # -- Define analysis --
     page.get_by_role("button", name="Define analysis").click()
     expect(page.get_by_text(analysis_release_warning)).not_to_be_visible()
+    expect(page.get_by_text(analysis_requirements_warning)).not_to_be_visible()
 
     # Pick grouping:
     page.locator(".selectize-input").nth(0).click()
@@ -189,6 +198,7 @@ def test_default_app_downloads(
     page.get_by_text("grade").nth(1).click()
 
     # -- Download Results --
+    expect(page.get_by_text(results_requirements_warning)).not_to_be_visible()
     page.get_by_role("button", name="Download Results").click()
 
     # Right now, the significant test start-up costs mean
@@ -221,10 +231,10 @@ def test_default_app_downloads(
         content = download.path().read_bytes()
         assert content  # Could add assertions for different document types.
 
-    # -- Define analysis --
+    # -- Define Analysis --
     page.get_by_role("tab", name="Define Analysis").click()
     expect(page.get_by_text(analysis_release_warning)).to_be_visible()
 
-    # -- Download Results --
+    # -- Select Dataset --
     page.get_by_role("tab", name="Select Dataset").click()
     expect(page.get_by_text(dataset_release_warning)).to_be_visible()


### PR DESCRIPTION
- Fix #32 

... though not actually locking. I think we're ok with a softer model.
- For the tabs where we haven't provided the prereqs, it's still useful to be able to look around and see what the rest of the app looks like.
- For after the release, we want to point out that the epsilon is spent, but since we can't keep people from just restarting the application, it doesn't make sense to lock it down hard.