### PR TITLE
use templated expr

### DIFF
--- a/dp_wizard/shiny/results_panel.py
+++ b/dp_wizard/shiny/results_panel.py
@@ -47,7 +47,7 @@ def button(
 
 def _strip_ansi(e):
     """
-    >>> e = Exception('\x1B[0;31mValueError\x1B[0m: ...')
+    >>> e = Exception('\x1b[0;31mValueError\x1b[0m: ...')
     >>> _strip_ansi(e)
     'ValueError: ...'
     """


### PR DESCRIPTION
- Towards #219 

The root problem is that details are duplicated between the templates and `db_helper.py`. The original thought was that db_helper code could be moved into shared, but that by itself wouldn't fix the problem: the templates are still necessary. Putting everything in shared would result in less readable, less idiomatic generated code.

The course proposed here is to `exec` the templated code, and in some sense there is less duplication now... but just looking at the diff, it's hard to argue that this is _actually_ simpler.

For the reviewer: Is it better to stick with the status quo, and tolerate some duplication of code, and close this PR without merging, and close the linked issue... or add complexity with `exec`, but have the polars expression in only one place? I'm on the fence.