### PR TITLE
in histogram results, rename len to count

### DIFF
--- a/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_query.py
+++ b/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_query.py
@@ -1,5 +1,5 @@
 groups = [BIN_NAME] + GROUP_NAMES
-QUERY_NAME = context.query().group_by(groups).agg(pl.len().dp.noise())
+QUERY_NAME = context.query().group_by(groups).agg(pl.len().dp.noise().alias("count"))
 ACCURACY_NAME = QUERY_NAME.summarize(alpha=1 - confidence)["accuracy"].item()
 STATS_NAME = QUERY_NAME.release().collect()
 STATS_NAME


### PR DESCRIPTION
- Fix #255

I think this came out of a conversation with Cheng Shi or Ellen: The default name of `len` is a little obscure.