### PR TITLE
Note about "None" for string valued columns

### DIFF
--- a/dp_wizard/shiny/__init__.py
+++ b/dp_wizard/shiny/__init__.py
@@ -47,27 +47,34 @@ def _make_demo_csv(path: Path, contributions):
     ...         rows = list(reader)
     ...         rows[0].values()
     ...         rows[-1].values()
-    ['student_id', 'class_year', 'hw_number', 'grade', 'self_assessment']
-    dict_values(['1', '2', '1', '82', '0'])
-    dict_values(['100', '2', '10', '78', '0'])
+    ['student_id', 'class_year_str', 'hw_number', 'grade', 'self_assessment']
+    dict_values(['1', 'sophomore', '1', '82', '0'])
+    dict_values(['100', 'sophomore', '10', '78', '0'])
     """
     random.seed(0)  # So the mock data will be stable across runs.
     with path.open("w", newline="") as demo_handle:
-        fields = ["student_id", "class_year", "hw_number", "grade", "self_assessment"]
+        fields = [
+            "student_id",
+            "class_year_str",
+            "hw_number",
+            "grade",
+            "self_assessment",
+        ]
+        class_year_map = ["first year", "sophomore", "junior", "senior"]
         writer = csv.DictWriter(demo_handle, fieldnames=fields)
         writer.writeheader()
         for student_id in range(1, 101):
-            class_year = int(_clip(random.gauss(2, 1), 1, 4))
+            class_year = int(_clip(random.gauss(1, 1), 0, 3))
             for hw_number in range(1, contributions + 1):
                 # Older students do slightly better in the class,
                 # but each assignment gets harder.
-                mean_grade = random.gauss(90, 5) + class_year * 2 - hw_number
+                mean_grade = random.gauss(90, 5) + (class_year + 1) * 2 - hw_number
                 grade = int(_clip(random.gauss(mean_grade, 5), 0, 100))
                 self_assessment = 1 if grade > 90 and random.random() > 0.1 else 0
                 writer.writerow(
                     {
                         "student_id": student_id,
-                        "class_year": class_year,
+                        "class_year_str": class_year_map[class_year],
                         "hw_number": hw_number,
                         "grade": grade,
                         "self_assessment": self_assessment,

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -41,7 +41,7 @@ def analysis_ui():
                 ),
                 ui.input_selectize(
                     "groups_selectize",
-                    "Group by",
+                    ["Group by", ui.output_ui("groups_selectize_tooltip_ui")],
                     [],
                     multiple=True,
                 ),
@@ -178,12 +178,23 @@ def analysis_server(
         _cleanup_reactive_dict(weights, column_ids_selected)
 
     @render.ui
+    def groups_selectize_tooltip_ui():
+        return demo_tooltip(
+            is_demo,
+            """
+            DP Wizard only supports the analysis of numeric data,
+            but string values can be used for grouping.
+            Select "class_year_str".
+            """,
+        )
+
+    @render.ui
     def columns_selectize_tooltip_ui():
         return demo_tooltip(
             is_demo,
             """
             Not all columns need analysis. For this demo, just check
-            "class_year" and "grade". With more columns selected,
+            "grade". With more columns selected,
             each column has a smaller share of the privacy budget.
             """,
         )

--- a/dp_wizard/shiny/components/column_module.py
+++ b/dp_wizard/shiny/components/column_module.py
@@ -309,12 +309,9 @@ def column_server(
         return demo_tooltip(
             is_demo,
             """
-            DP requires that we limit the sensitivity to the contributions
-            of any individual. To do this, we need an estimate of the lower
-            and upper bounds for each variable. We should not look at the
-            data when estimating the bounds! In this case, we could imagine
-            that "class year" would vary between 1 and 4, and we could limit
-            "grade" to values between 50 and 100.
+            We need to clip our inputs to limit sensitivity.
+            Don't look at the data when estimating the bounds!
+            In this case, we could limit "grade" to values between 50 and 100.
             """,
         )
 
@@ -323,11 +320,10 @@ def column_server(
         return demo_tooltip(
             is_demo,
             """
-            Different statistics can be measured with DP.
-            This tool provides a histogram. If you increase the number of bins,
+            If you increase the number of bins,
             you'll see that each individual bin becomes noisier to provide
-            the same overall privacy guarantee. For this example, give
-            "class_year" 4 bins and "grade" 5 bins.
+            the same overall privacy guarantee.
+            Give "grade" 5 bins.
             """,
         )
 

--- a/dp_wizard/shiny/results_panel.py
+++ b/dp_wizard/shiny/results_panel.py
@@ -47,7 +47,7 @@ def button(
 
 def _strip_ansi(e):
     """
-    >>> e = Exception('\x1B[0;31mValueError\x1B[0m: ...')
+    >>> e = Exception('\x1b[0;31mValueError\x1b[0m: ...')
     >>> _strip_ansi(e)
     'ValueError: ...'
     """

--- a/dp_wizard/utils/code_generators/abstract_generator.py
+++ b/dp_wizard/utils/code_generators/abstract_generator.py
@@ -133,11 +133,13 @@ class AbstractGenerator(ABC):
             accuracy_name=accuracy_name,
             stats_name=stats_name,
         )
+        note = analysis.make_note()
 
         return (
             self._make_comment_cell(f"### Query for `{column_name}`:")
             + self._make_python_cell(query)
             + self._make_python_cell(output)
+            + (self._make_comment_cell(note) if note else "")
         )
 
     def _make_partial_context(self):

--- a/dp_wizard/utils/code_generators/analyses/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/__init__.py
@@ -28,6 +28,9 @@ class Analysis(Protocol):  # pragma: no cover
     ) -> str: ...
 
     @staticmethod
+    def make_note() -> str: ...
+
+    @staticmethod
     def make_report_kv(
         name: str,
         confidence: float,

--- a/dp_wizard/utils/code_generators/analyses/histogram/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/histogram/__init__.py
@@ -40,6 +40,10 @@ def make_output(code_gen, column_name, accuracy_name, stats_name):
     )
 
 
+def make_note():
+    return "`None` values above may indicate strings which could not be converted to numbers."
+
+
 def make_report_kv(name, confidence, identifier):
     return (
         Template("histogram_report_kv", __file__)

--- a/dp_wizard/utils/code_generators/analyses/mean/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/mean/__init__.py
@@ -34,6 +34,10 @@ def make_output(code_gen, column_name, accuracy_name, stats_name):
     )
 
 
+def make_note():
+    return ""
+
+
 def make_report_kv(name, confidence, identifier):
     return (
         Template("mean_report_kv", __file__)

--- a/dp_wizard/utils/code_generators/analyses/median/__init__.py
+++ b/dp_wizard/utils/code_generators/analyses/median/__init__.py
@@ -29,6 +29,10 @@ def make_output(code_gen, column_name, accuracy_name, stats_name):
     ).finish()  # pragma: no cover
 
 
+def make_note():
+    return ""
+
+
 def make_report_kv(name, confidence, identifier):
     return (
         Template("median_report_kv", __file__)


### PR DESCRIPTION
- Fix #394 
- Update the demo CSV and tooltips: use a string column for grouping.

Does this seem sufficient to close the issue? At notebook generation time we can't look at the data, so we can't tell whether there are `None`s or not.

A couple times the idea of prompting for the types of columns has been suggested, and we might end up there, but I'd like to understand the usecases before we jump into implementing that. I think there are at least two cases to be distinguished:

- User knows their data and marks a column as string. 👉 We don't let them do a numeric analysis on this column.
  - ... but for me, this doesn't seem like a good motivation, because if they understand the column is a string, I'd trust them not to try to take the mean: not worth adding UI complexity.
- or: user doesn't know that there are strings lurking in the column 👉 so we can't trust the types supplied by the user
  - ... and we still need to explain odd downstream results.

Maybe there are other use cases you have in mind, or maybe your analysis is different?

for the reviewer:
- If this is better than the status quo, please approve.
- If you think this resolves the linked issue, great!
- If this is ok, but doesn't really resolve the issue, that's good too: I can unlink the issue, and we can discuss what a real fix would look like.... but hopefully not in this PR.