### PR TITLE
Histograms do not need margins

### DIFF
--- a/dp_wizard/shiny/results_panel.py
+++ b/dp_wizard/shiny/results_panel.py
@@ -47,7 +47,7 @@ def button(
 
 def _strip_ansi(e):
     """
-    >>> e = Exception('\x1B[0;31mValueError\x1B[0m: ...')
+    >>> e = Exception('\x1b[0;31mValueError\x1b[0m: ...')
     >>> _strip_ansi(e)
     'ValueError: ...'
     """

--- a/dp_wizard/utils/code_generators/abstract_generator.py
+++ b/dp_wizard/utils/code_generators/abstract_generator.py
@@ -4,6 +4,7 @@ from dp_wizard.utils.code_generators import (
     make_privacy_loss_block,
     make_privacy_unit_block,
 )
+from dp_wizard.utils.code_generators.analyses import histogram
 from dp_wizard.utils.code_template import Template
 from dp_wizard.utils.csv_helper import name_to_identifier
 from dp_wizard.utils.dp_helper import confidence
@@ -154,9 +155,18 @@ class AbstractGenerator(ABC):
         privacy_unit_block = make_privacy_unit_block(self.contributions)
         privacy_loss_block = make_privacy_loss_block(self.epsilon)
 
-        margins_list = self._make_margins_list(
-            [f"{name}_bin" for name in bin_column_names],
-            self.groups,
+        is_just_histograms = all(
+            plan_column.analysis_type == histogram.name
+            for plan_column in self.columns.values()
+        )
+        margins_list = (
+            # Histograms don't need margins.
+            "[]"
+            if is_just_histograms
+            else self._make_margins_list(
+                [f"{name}_bin" for name in bin_column_names],
+                self.groups,
+            )
         )
         extra_columns = ", ".join(
             [


### PR DESCRIPTION
- Towards #371
- Means and medians still need work.

Motivation: When making example code for the user, we don't want to use unnecessary features, or weaken any of our privacy assumptions. Histograms don't need margins, so we shouldn't include them where they aren't necessary.