### PR TITLE
Analysis inputs empty by default

### DIFF
--- a/dp_wizard/shiny/__init__.py
+++ b/dp_wizard/shiny/__init__.py
@@ -112,6 +112,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
 
         public_csv_path = reactive.value("")
         analysis_types = reactive.value({})
+        analysis_errors = reactive.value({})
         lower_bounds = reactive.value({})
         upper_bounds = reactive.value({})
         bin_counts = reactive.value({})
@@ -149,6 +150,7 @@ def make_server_from_cli_info(cli_info: CLIInfo):
             column_names=column_names,
             contributions=contributions,
             analysis_types=analysis_types,
+            analysis_errors=analysis_errors,
             lower_bounds=lower_bounds,
             upper_bounds=upper_bounds,
             bin_counts=bin_counts,

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -110,6 +110,7 @@ def analysis_server(
     contributions: reactive.Value[int],
     is_demo: bool,
     analysis_types: reactive.Value[dict[str, str]],
+    analysis_errors: reactive.Value[dict[str, bool]],
     lower_bounds: reactive.Value[dict[str, float]],
     upper_bounds: reactive.Value[dict[str, float]],
     bin_counts: reactive.Value[dict[str, int]],
@@ -119,8 +120,9 @@ def analysis_server(
 ):  # pragma: no cover
     @reactive.calc
     def button_enabled():
-        column_ids_selected = input.columns_selectize()
-        return len(column_ids_selected) > 0
+        at_least_one_column = len(input.columns_selectize()) > 0
+        no_errors = not any(analysis_errors().values())
+        return at_least_one_column and no_errors
 
     @reactive.effect
     def _update_columns():
@@ -257,6 +259,7 @@ def analysis_server(
                 epsilon=epsilon(),
                 row_count=int(input.row_count()),
                 analysis_types=analysis_types,
+                analysis_errors=analysis_errors,
                 lower_bounds=lower_bounds,
                 upper_bounds=upper_bounds,
                 bin_counts=bin_counts,

--- a/dp_wizard/shiny/components/column_module.py
+++ b/dp_wizard/shiny/components/column_module.py
@@ -224,7 +224,7 @@ def column_server(
             return ui.input_text(
                 "lower_bound",
                 ["Lower Bound", ui.output_ui("bounds_tooltip_ui")],
-                str(lower_bounds().get(name, 0)),
+                str(lower_bounds().get(name, "")),
                 width=label_width,
             )
 
@@ -232,7 +232,7 @@ def column_server(
             return ui.input_text(
                 "upper_bound",
                 "Upper Bound",
-                str(upper_bounds().get(name, 10)),
+                str(upper_bounds().get(name, "")),
                 width=label_width,
             )
 
@@ -240,7 +240,7 @@ def column_server(
             return ui.input_numeric(
                 "bins",
                 ["Number of Bins", ui.output_ui("bins_tooltip_ui")],
-                bin_counts().get(name, 10),
+                bin_counts().get(name, 0),
                 width=label_width,
             )
 
@@ -251,7 +251,7 @@ def column_server(
             return ui.input_numeric(
                 "bins",
                 "Number of Candidates",
-                bin_counts().get(name, 10),
+                bin_counts().get(name, 0),
                 width=label_width,
             )
 

--- a/dp_wizard/shiny/components/column_module.py
+++ b/dp_wizard/shiny/components/column_module.py
@@ -117,6 +117,7 @@ def column_server(
     epsilon: float,
     row_count: int,
     analysis_types: reactive.Value[dict[str, str]],
+    analysis_errors: reactive.Value[dict[str, bool]],
     lower_bounds: reactive.Value[dict[str, float]],
     upper_bounds: reactive.Value[dict[str, float]],
     bin_counts: reactive.Value[dict[str, int]],
@@ -240,7 +241,7 @@ def column_server(
             return ui.input_numeric(
                 "bins",
                 ["Number of Bins", ui.output_ui("bins_tooltip_ui")],
-                bin_counts().get(name, 0),
+                bin_counts().get(name, 10),
                 width=label_width,
             )
 
@@ -330,6 +331,12 @@ def column_server(
     @reactive.calc
     def error_md_calc():
         return get_bound_error(input.lower_bound(), input.upper_bound())
+
+    @reactive.effect
+    def set_analysis_errors():
+        with reactive.isolate():
+            prev_analysis_errors = analysis_errors()
+        analysis_errors.set({**prev_analysis_errors, name: bool(error_md_calc())})
 
     @render.code
     def column_code():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,6 +38,8 @@ def test_qa_app(page: Page, qa_app: ShinyAppProc):  # pragma: no cover
 
     page.locator(".selectize-input").nth(0).click()
     page.get_by_text(": grade").click()
+    page.get_by_label("Lower").fill("0")
+    page.get_by_label("Upper").fill("10")
 
     page.get_by_role("button", name="Download Results").click()
     page.get_by_role("link", name="Download Notebook (.ipynb)").click()
@@ -195,6 +197,9 @@ def test_local_app_downloads(page: Page, local_app: ShinyAppProc):  # pragma: no
     # Pick grouping:
     page.locator(".selectize-input").nth(1).click()
     page.get_by_text("class year").nth(2).click()
+    # Fill inputs:
+    page.get_by_label("Lower").fill("0")
+    page.get_by_label("Upper").fill("10")
 
     # -- Download Results --
     expect(page.get_by_text(results_requirements_warning)).not_to_be_visible()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,15 +134,11 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
     page.get_by_text(": class year").nth(2).click()
 
     # Check that default is set correctly:
-    # (Explicit "float()" because sometimes returns "10", sometimes "10.0".
-    #  Weird, but not something to spend time on.)
-    assert float(page.get_by_label("Upper").input_value()) == 10.0
-
-    # Input validation:
-    page.get_by_label("Upper").fill("")
+    assert page.get_by_label("Upper").input_value() == ""
     expect_visible("Upper bound is required")
     page.get_by_label("Upper").fill("nan")
     expect_visible("Upper bound should be a number")
+    page.get_by_label("Lower").fill("0")
     page.get_by_label("Upper").fill("-1")
     expect_visible("Lower bound should be less than upper bound")
 


### PR DESCRIPTION
- Fix #501

The root problem is that we've seen users glide through without taking time to change bounds. If bounds start off empty, and there's a validation error message, then they need to make a conscious choice before moving forward.

Showing the validation error message on load might be a little weird, but if it reads as a todo list rather than a you-did-something-wrong message, it probably works? **Would appreciate feedback on this!**

This is only checking the bounds right now. #489 adds validation for bin count, but the framework doesn't let numeric values be empty, and setting it to zero or one might just be more confusing: I hope people will see the 10 bars in the bar chart, and they can make their own decision if that's right for them. **Would it be good to change bin count to a string so it could also start off empty?** Would lose the increment/decrement buttons in the UI.

I have a separate issue (#498) to work on the unit of privacy UI.