### PR TITLE
better docs about quoting for Windows users

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -23,7 +23,7 @@ DP Wizard requires Python 3.10 or later.
 You can check your current version with `python --version`.
 The exact upgrade process will depend on your environment and operating system.
 
-Install with `pip install dp_wizard[app]` and you can start DP Wizard from the command line.
+Install with `pip install 'dp_wizard[app]'` and you can start DP Wizard from the command line.
 
 ```
 usage: dp-wizard [-h] [--demo | --cloud]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DP Wizard requires Python 3.10 or later.
 You can check your current version with `python --version`.
 The exact upgrade process will depend on your environment and operating system.
 
-Install with `pip install dp_wizard[app]` and you can start DP Wizard from the command line.
+Install with `pip install 'dp_wizard[app]'` and you can start DP Wizard from the command line.
 
 ```
 usage: dp-wizard [-h] [--demo | --cloud]
@@ -127,8 +127,9 @@ If Playwright fails in CI, we can still see what went wrong:
 - Publish: `flit publish --pypirc .pypirc`
 
 This project is configured so there are two different install possibilities from pypi:
-- `pip install dp_wizard` does not aggressively pin dependency versions. It is preferred if you're using `dp_wizard` as a library.
-- `pip install dp_wizard[app]` pins all dependencies, and will work more reliably for application users.
+- `pip install 'dp_wizard[app]'` pins all dependencies, and is the best route for most users.
+- `pip install dp_wizard` does not pin dependencies, and is best if you're using `dp_wizard` as a library.
+
 
 The cloud deployment is [configured](https://connect.posit.cloud/mccalluc/content/01966942-7eab-da99-0887-a7c483756aa8/edit) to update on pushes to the `cloud-deployment` branch.
 If you are on `main`, with no local changes, run `scripts/deploy.sh`.

--- a/dp_wizard/utils/code_generators/abstract_generator.py
+++ b/dp_wizard/utils/code_generators/abstract_generator.py
@@ -54,7 +54,8 @@ class AbstractGenerator(ABC):
             .fill_expressions(
                 TITLE=str(self.analysis_plan),
                 DEPENDENCIES="'opendp[polars]==0.13.0' matplotlib",
-                WINDOWS_NOTE="(If installing in the Windows CMD shell, use double-quotes instead of single-quotes above.)",
+                WINDOWS_NOTE="(If installing in the Windows CMD shell, "
+                "use double-quotes instead of single-quotes above.)",
             )
             .fill_blocks(
                 IMPORTS_BLOCK=Template(template).finish(),

--- a/dp_wizard/utils/code_generators/abstract_generator.py
+++ b/dp_wizard/utils/code_generators/abstract_generator.py
@@ -54,6 +54,7 @@ class AbstractGenerator(ABC):
             .fill_expressions(
                 TITLE=str(self.analysis_plan),
                 DEPENDENCIES="'opendp[polars]==0.13.0' matplotlib",
+                WINDOWS_NOTE="(If installing in the Windows CMD shell, use double-quotes instead of single-quotes above.)",
             )
             .fill_blocks(
                 IMPORTS_BLOCK=Template(template).finish(),

--- a/dp_wizard/utils/code_generators/no-tests/_notebook.py
+++ b/dp_wizard/utils/code_generators/no-tests/_notebook.py
@@ -6,6 +6,7 @@
 # ## Prerequisites
 #
 # First install and import the required dependencies:
+# WINDOWS_NOTE
 
 # +
 # %pip install DEPENDENCIES

--- a/dp_wizard/utils/code_generators/no-tests/_script.py
+++ b/dp_wizard/utils/code_generators/no-tests/_script.py
@@ -4,6 +4,7 @@ TITLE
 
 # Install the following dependencies, if you haven't already:
 # pip install DEPENDENCIES
+# WINDOWS_NOTE
 
 from argparse import ArgumentParser
 


### PR DESCRIPTION
- Fix #391, I think.
- Replaces #392: Trying to sniff the OS and generating different notebook content is too complicated!
- I realized the instructions in the README also need to be fixed: Without quotes, the `[]` are treated as metacharacters by bash.

For the reviewer: Do these explanations seem useful, without being a distraction for non-windows users?