### PR TITLE
Make the epsilon slider finer grained

### DIFF
--- a/dp_wizard/shiny/components/inputs.py
+++ b/dp_wizard/shiny/components/inputs.py
@@ -41,5 +41,5 @@ def log_slider(id: str, lower_bound: float, upper_bound: float):
 </style>
 """
         ),
-        ui.input_slider(id, None, log10(lower_bound), log10(upper_bound), 0, step=0.1),
+        ui.input_slider(id, None, log10(lower_bound), log10(upper_bound), 0, step=0.02),
     ]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -134,9 +134,7 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
     # Epsilon slider:
     expect_visible("Epsilon: 1.0")
     page.locator(".irs-bar").click()
-    expect_visible("Epsilon: 0.316")
-    page.locator(".irs-bar").click()
-    expect_visible("Epsilon: 0.158")
+    expect_visible("Epsilon: 0.288")
     # Simulation
     expect_visible("Because you've provided a public CSV")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -173,7 +173,7 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
     new_value = "20"
     page.get_by_label("Upper").fill(new_value)
     assert float(page.get_by_label("Upper").input_value()) == float(new_value)
-    expect_visible("The 95% confidence interval is ±794")
+    expect_visible("The 95% confidence interval is ±437")
     page.get_by_text("Data Table").click()
     expect_visible(f"({new_value}, inf]")  # Because values are well above the bins.
 


### PR DESCRIPTION
- Fix #497

With this change, increments are not quite down to the pixel level, but they are small.

The user can get much closer to some integer values, which I think is one of the main desires.

- 2.0
- 3.02
- 3.98
- 5.01
- 6.03

I feel some ambivalence about this. If we need to give users more precise control, it really should be over the error margin, not the epsilon.