### PR TITLE
Fix race condition in playwright tests, hopefully

### DIFF
--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -119,8 +119,7 @@ def analysis_server(
 ):  # pragma: no cover
     @reactive.calc
     def button_enabled():
-        column_ids_selected = input.columns_selectize()
-        return len(column_ids_selected) > 0
+        return bool(weights())
 
     @reactive.effect
     def _update_columns():
@@ -304,11 +303,12 @@ def analysis_server(
 
     @render.ui
     def download_results_button_ui():
+        is_enabled = button_enabled()
         button = nav_button(
-            "go_to_results", "Download Results", disabled=not button_enabled()
+            "go_to_results", "Download Results", disabled=not is_enabled
         )
 
-        if button_enabled():
+        if is_enabled:
             return button
         return [
             button,


### PR DESCRIPTION
- Fix #510

`analysis_panel.py` used this logic to determine whether to enable the download button:
```
column_ids_selected = input.columns_selectize()
return len(column_ids_selected) > 0
```
but `results_panel.py` uses this:
```
disabled = not weights()
```

It seems like in automated testing it must be possible for a column to be selected, but for a fraction of a second the weights aren't updated. Hope that using `weights()` everywhere will fix the race condition.