### PR TITLE
Round the epsilon values

### DIFF
--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -21,6 +21,7 @@ from dp_wizard.utils.csv_helper import (
     id_labels_dict_from_names,
     id_names_dict_from_names,
 )
+from dp_wizard.utils.shared import round_2
 
 
 def analysis_ui():
@@ -100,6 +101,26 @@ def _cleanup_reactive_dict(
     for key in keys_to_del:
         del reactive_dict_copy[key]
     reactive_dict.set(reactive_dict_copy)
+
+
+def _trunc_pow(exponent):
+    """
+    The output should be roughly exponential,
+    but should also be round numbers,
+    so it doesn't seem too arbitrary to the user.
+    >>> _trunc_pow(-1)
+    0.1
+    >>> _trunc_pow(-0.5)
+    0.3
+    >>> _trunc_pow(0)
+    1.0
+    >>> _trunc_pow(0.5)
+    3.0
+    >>> _trunc_pow(1)
+    10.0
+    """
+    number = pow(10, exponent)
+    return float(f"{number:.2g}" if abs(exponent) < 0.5 else f"{number:.1g}")
 
 
 def analysis_server(
@@ -333,12 +354,12 @@ def analysis_server(
     @reactive.effect
     @reactive.event(input.log_epsilon_slider)
     def _set_epsilon():
-        epsilon.set(pow(10, input.log_epsilon_slider()))
+        epsilon.set(_trunc_pow(input.log_epsilon_slider()))
 
     @render.ui
     def epsilon_ui():
         return tags.label(
-            f"Epsilon: {epsilon():0.3} ",
+            f"Epsilon: {epsilon()} ",
             tutorial_box(
                 is_tutorial_mode(),
                 """

--- a/dp_wizard/shiny/analysis_panel.py
+++ b/dp_wizard/shiny/analysis_panel.py
@@ -21,7 +21,6 @@ from dp_wizard.utils.csv_helper import (
     id_labels_dict_from_names,
     id_names_dict_from_names,
 )
-from dp_wizard.utils.shared import round_2
 
 
 def analysis_ui():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -132,9 +132,9 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
     # Epsilon slider:
     expect(page.get_by_text("Epsilon: 1.0")).to_be_visible()
     page.locator(".irs-bar").click()
-    expect(page.get_by_text("Epsilon: 0.316")).to_be_visible()
+    expect(page.get_by_text("Epsilon: 0.3")).to_be_visible()
     page.locator(".irs-bar").click()
-    expect(page.get_by_text("Epsilon: 0.158")).to_be_visible()
+    expect(page.get_by_text("Epsilon: 0.2")).to_be_visible()
     # Simulation
     expect(page.get_by_text("Because you've provided a public CSV")).to_be_visible()
 
@@ -179,7 +179,7 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
     new_value = "20"
     page.get_by_label("Upper").fill(new_value)
     assert float(page.get_by_label("Upper").input_value()) == float(new_value)
-    expect(page.get_by_text("The 95% confidence interval is ±48.1")).to_be_visible()
+    expect(page.get_by_text("The 95% confidence interval is ±60.4")).to_be_visible()
     page.get_by_text("Data Table").click()
     expect(
         page.get_by_text(f"({new_value}, inf]")


### PR DESCRIPTION
- Fix #497

Having the precise values of the exponential was a little frustrating to users, because it wasn't clear where these values were coming from. I hope this will be better, but the long-run plan is to focus more on accuracy than on epsilon, so I wouldn't overdo this.