### PR TITLE
get rid of extra padding at bottom

### DIFF
--- a/dp_wizard/shiny/assets/styles.css
+++ b/dp_wizard/shiny/assets/styles.css
@@ -16,6 +16,15 @@ code {
     padding: 0 !important;
 }
 
+p:last-of-type {
+    /* Inside tutorial boxes: */
+    margin-bottom: 0;
+}
+ul:last-of-type {
+    /* Lists of errors: */
+    margin-bottom: 0;
+}
+
 /*
 Improve readability of popover.
 */


### PR DESCRIPTION
- Fix #589 

Before:
<img width="291" height="306" alt="before" src="https://github.com/user-attachments/assets/ddc04069-b812-4c2a-b0bd-8c48ca61304f" />

After:
<img width="326" height="294" alt="after" src="https://github.com/user-attachments/assets/c1f254ef-6994-4d32-8510-8b34ace703da" />
