### PR TITLE
Show messages instead of numbers on epsilon sliders

### DIFF
--- a/dp_wizard/shiny/components/inputs.py
+++ b/dp_wizard/shiny/components/inputs.py
@@ -5,7 +5,13 @@ from shiny import ui
 from dp_wizard.shiny.components.outputs import only_for_screenreader
 
 
-def log_slider(id: str, lower_bound: float, upper_bound: float):
+def log_slider(
+    id: str,
+    lower_bound: float,
+    upper_bound: float,
+    lower_message: str = "",
+    upper_message: str = "",
+):
     # Rather than engineer a new widget, hide the numbers we don't want,
     # and insert the log values via CSS.
     # "display" and "visibility" were also hiding the content provided via CSS,
@@ -14,6 +20,8 @@ def log_slider(id: str, lower_bound: float, upper_bound: float):
     # The rendered widget doesn't have a unique ID, but the following
     # element does, so we can use some fancy CSS to get the preceding element.
     # Long term solution is just to make our own widget.
+    lower_content = lower_message if lower_message else lower_bound
+    upper_content = upper_message if upper_message else upper_bound
     return [
         ui.HTML(
             f"""
@@ -33,12 +41,12 @@ def log_slider(id: str, lower_bound: float, upper_bound: float):
 }}
 .irs:has(+ #{id}) .irs-min::before {{
     /* ... and instead show lower ... */
-    content: "{lower_bound}";
+    content: "{lower_content}";
     font-size: 12px;
 }}
 .irs:has(+ #{id}) .irs-max::after {{
     /* ... and upper bounds. */
-    content: "{upper_bound}";
+    content: "{upper_content}";
     font-size: 12px;
 }}
 </style>

--- a/dp_wizard/shiny/panels/analysis_panel/__init__.py
+++ b/dp_wizard/shiny/panels/analysis_panel/__init__.py
@@ -80,7 +80,13 @@ def analysis_ui():
                        target="_blank">other projects</a>.
                     """
                 ),
-                log_slider("log_epsilon_slider", 0.1, 10.0),
+                log_slider(
+                    "log_epsilon_slider",
+                    lower_bound=0.1,
+                    upper_bound=10.0,
+                    lower_message="Better Privacy",
+                    upper_message="Better Accuracy",
+                ),
                 ui.output_ui("epsilon_ui"),
                 ui.output_ui("privacy_loss_python_ui"),
             ),


### PR DESCRIPTION
We want to de-emphasize picking a particular, precise value; On the other hand, we want to make it more clear to users what the trade-offs are. You could imagine someone thinking a big privacy budget means big privacy!

- Fix #726 

<img width="269" height="90" alt="Screenshot 2025-11-18 at 12 03 58 PM" src="https://github.com/user-attachments/assets/58589c6d-6668-46f8-9394-d414c42057da" />

For reviewer:
- Is the text good? In an earlier draft I had "More privacy / More accuracy"


