### PR TITLE
Misc: Weight enum, testing improvements

### DIFF
--- a/dp_wizard/shiny/components/icons.py
+++ b/dp_wizard/shiny/components/icons.py
@@ -1,5 +1,7 @@
 from faicons import icon_svg
 
+# Find more icons on Font Awesome: https://fontawesome.com/search?ic=free
+
 data_source_icon = icon_svg("file")
 unit_of_privacy_icon = icon_svg("shield-halved")
 product_icon = icon_svg("cart-shopping")

--- a/dp_wizard/shiny/panels/results_panel/__init__.py
+++ b/dp_wizard/shiny/panels/results_panel/__init__.py
@@ -264,7 +264,7 @@ def results_server(
                     lower_bound=lower_bounds()[col],
                     upper_bound=upper_bounds()[col],
                     bin_count=int(bin_counts()[col]),
-                    weight=int(weights()[col]),
+                    weight=int(weights()[col].value),
                 )
             ]
             for col in weights().keys()

--- a/dp_wizard/types.py
+++ b/dp_wizard/types.py
@@ -5,6 +5,22 @@ from enum import Enum, auto
 from shiny import reactive
 
 
+class Weight(Enum):
+    """
+    >>> print(Weight.MORE_ACCURATE)
+    More accurate
+    >>> ints = [int(w.value) for w in Weight]
+    >>> assert ints[2] / ints[1] == ints[1] / ints[0]
+    """
+
+    MORE_PRIVATE = "1"
+    DEFAULT = "2"
+    MORE_ACCURATE = "4"
+
+    def __str__(self) -> str:
+        return self.name.replace("_", " ").capitalize()
+
+
 class Product(Enum):
     STATISTICS = auto()
     SYNTHETIC_DATA = auto()
@@ -109,7 +125,7 @@ class AppState:
     lower_bounds: reactive.Value[dict[ColumnName, float]]
     upper_bounds: reactive.Value[dict[ColumnName, float]]
     bin_counts: reactive.Value[dict[ColumnName, int]]
-    weights: reactive.Value[dict[ColumnName, str]]
+    weights: reactive.Value[dict[ColumnName, Weight]]
     analysis_errors: reactive.Value[dict[ColumnName, bool]]
 
     # Release state:

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -107,7 +107,7 @@ hw_grade_bin_expr = (
     )
 
 
-abc_csv = "tests/fixtures/abc.csv"
+abc_csv_path = str((package_root.parent / "tests/fixtures/abc.csv").absolute())
 
 
 def number_lines(text: str):
@@ -141,22 +141,17 @@ median_plan_column = AnalysisPlanColumn(
 
 
 def id_for_plan(plan: AnalysisPlan):
-    columns = ", ".join(f"{v[0].analysis_name} of {k}" for k, v in plan.columns.items())
-    description = (
-        f"{plan.product} for {columns}; "
-        f"grouped by ({', '.join(plan.groups) or 'nothing'})"
-    )
-    return re.sub(r"\W+", "_", description)  # For selection with "pytest -k substring"
+    return re.sub(r"\W+", "_", str(plan))  # For selection with "pytest -k substring"
 
 
-plans = [
+plans_all_combos = [
     AnalysisPlan(
         product=product,
         groups=groups,
         columns=columns,
         contributions=contributions,
         contributions_entity="Family",
-        csv_path=abc_csv,
+        csv_path=abc_csv_path,
         epsilon=1,
         max_rows=100_000,
     )
@@ -176,6 +171,13 @@ plans = [
         },
     ]
 ]
+
+
+# The matrix is very redundant! A subsample is sufficient,
+# but make sure it's relatively prime so we have coverage.
+mod = 7
+assert len(plans_all_combos) % mod != 0
+plans = [plan for i, plan in enumerate(plans_all_combos) if i % 7 == 0]
 
 
 expected_urls = [
@@ -230,6 +232,7 @@ def test_make_notebook(plan):
 @pytest.mark.parametrize("plan", plans, ids=id_for_plan)
 def test_make_script(plan):
     script = ScriptGenerator(plan, "Note goes here!").make_py()
+    print(number_lines(script))
 
     # Make sure jupytext formatting doesn't bleed into the script.
     # https://jupytext.readthedocs.io/en/latest/formats-scripts.html#the-light-format
@@ -241,6 +244,6 @@ def test_make_script(plan):
         fp.flush()
 
         result = subprocess.run(
-            ["python", fp.name, "--csv", abc_csv], capture_output=True
+            ["python", fp.name, "--csv", abc_csv_path], capture_output=True
         )
         assert result.returncode == 0


### PR DESCRIPTION
- From #725

The counts PR should be redone from scratch, since we decided it would be better to always do a DP count. That said, there are several other good changes in that PR that should be kept:
- Weights enum strengthens our type signatures
- Subsetting tests helps them run in a reasonable period of time.
- Include a full path to the CSV fixture in generated code, so it can be run out of the box.