### PR TITLE
Yellow warning box for high/low epsilon

### DIFF
--- a/dp_wizard/shiny/panels/analysis_panel/__init__.py
+++ b/dp_wizard/shiny/panels/analysis_panel/__init__.py
@@ -418,19 +418,24 @@ def analysis_server(
     @render.ui
     def epsilon_ui():
         e_value = epsilon()
-        extra = ""
+        optional_warning = None
         if e_value >= 5:
-            extra = (
-                ": The use of a value this **large** is discouraged "
-                "because it may compromise privacy."
+            optional_warning = warning_md_box(
+                """
+                The use of a value this large is discouraged
+                because high accuracy may compromise privacy.
+                """
             )
         if e_value <= 0.2:
-            extra = (
-                ": The use of a value this **small** is discouraged "
-                "because the additional noise will lower the accuracy of results."
+            optional_warning = warning_md_box(
+                """
+                The use of a value this small is discouraged
+                because added noise will lower the accuracy of results.
+                """
             )
         return [
-            ui.markdown(f"Privacy Budget (Epsilon): {e_value}{extra}"),
+            ui.markdown(f"Privacy Budget (Epsilon): {e_value}"),
+            optional_warning,
             tutorial_box(
                 is_tutorial_mode(),
                 """


### PR DESCRIPTION
- Fix #785
- Separate the warning from the epsilon value
- Tweak wording
<img width="283" height="376" alt="Screenshot 2026-01-06 at 3 14 55 PM" src="https://github.com/user-attachments/assets/57379901-3e7e-4a36-b263-6736037f77aa" />


