### PR TITLE
Dependabot upgrade and TODO

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -19,5 +19,8 @@ pytest-cov
 pytest-xdist
 diffimg
 
+# Dependabot warnings:
+filelock>=3.20.1
+
 # App dependencies:
 -r requirements.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -91,8 +91,10 @@ faicons==0.2.2
     # via -r .../dp-wizard/requirements.in
 fastjsonschema==2.21.1
     # via nbformat
-filelock==3.18.0
-    # via virtualenv
+filelock==3.20.2
+    # via
+    #   -r requirements-dev.in
+    #   virtualenv
 flake8==7.2.0
     # via
     #   -r requirements-dev.in

--- a/requirements.in
+++ b/requirements.in
@@ -20,3 +20,7 @@ urllib3>=2.6.0
 pillow>=11.3.0
 starlette>=0.49.1
 fonttools>=4.60.2
+
+# TODO: Upgrade when fix is available.
+# https://github.com/opendp/dp-wizard/security/dependabot/35
+# nbconvert


### PR DESCRIPTION
- Fix https://github.com/opendp/dp-wizard/security/dependabot/34
- For the nbconvert errors, there isn't a higher version out yet... but we don't convert to PDF either, so I'm not worried.