### PR TITLE
restore tooltips, but color blue

### DIFF
--- a/dp_wizard/shiny/assets/styles.css
+++ b/dp_wizard/shiny/assets/styles.css
@@ -31,7 +31,8 @@ Improve readability of popover.
 .tooltip-inner {
     text-align: left;
     color: black;
-    background-color: lightgray;
+    background-color: var(--bs-info-bg-subtle);
+    border-color: var(--bs-info-bg-subtle);
     opacity: 100%;
 }
 /*
@@ -40,16 +41,16 @@ The tooltip is positioned to avoid falling outside of the window,
 so any of these might be applied.
 */
 .bs-tooltip-auto[data-popper-placement^="right"] .tooltip-arrow::before {
-    border-right-color: lightgrey;
+    border-right-color: var(--bs-info-bg-subtle);
 }
 .bs-tooltip-auto[data-popper-placement^="bottom"] .tooltip-arrow::before {
-    border-bottom-color: lightgray;
+    border-bottom-color: var(--bs-info-bg-subtle);
 }
 .bs-tooltip-auto[data-popper-placement^="left"] .tooltip-arrow::before {
-    border-left-color: lightgrey;
+    border-left-color: var(--bs-info-bg-subtle);
 }
 .bs-tooltip-auto[data-popper-placement^="top"] .tooltip-arrow::before {
-    border-top-color: lightgray;
+    border-top-color: var(--bs-info-bg-subtle);
 }
 
 /*

--- a/dp_wizard/shiny/components/outputs.py
+++ b/dp_wizard/shiny/components/outputs.py
@@ -77,6 +77,11 @@ def tutorial_box(
             # Using columns here makes sure we line up with panels below.
             columns.append(None)
         return ui.layout_columns(*columns)
+    else:
+        return ui.tooltip(
+            tutorial_icon,
+            ui.markdown(markdown),
+        )
 
 
 def hide_if(condition: bool, el):  # pragma: no cover


### PR DESCRIPTION
- Fix #855

Keeping this as draft, but asking for review, to see if this should go forward. The existing help boxes are all-or-nothing. If you turn them off, you won't even see that you're missing something. The proposal is to bring tooltips back.

There are a couple challenges here:
- We have some long descriptions which don't work so well as tooltips... even with CSS so the boxes aren't as narrow.
- Where should the circle-question-marks go?

For the reviewer:
- Does the benefit of this seem like it will be worth the CSS wrangling required?