### PR TITLE
"CSV" to "CSV or TSV" or "data source"

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -51,7 +51,7 @@ options:
   --no_browser  By default, a browser is started; Enable this for no browser.
   --reload      Enable to watch source directory and reload on changes.
 
-Unless you have set "--demo", you will specify a CSV inside the application.
+Unless you have set "--demo", you will specify a CSV or TSV inside the application.
 
 Provide a "Private Data" if you only have a private data set, and want to
 make a release from it: The preview visualizations will only use
@@ -61,7 +61,7 @@ read until the release.
 Provide a "Public Data" if you have a public data set, and are curious how
 DP can be applied: The preview visualizations will use your public data.
 
-Provide both if you have two CSVs with the same structure.
+Provide both if you have two CSVs or TSVs with the same structure.
 Perhaps the public data is older and no longer sensitive. Preview
 visualizations will be made with the public data, but the release will
 be made with private data.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ options:
   --no_browser  By default, a browser is started; Enable this for no browser.
   --reload      Enable to watch source directory and reload on changes.
 
-Unless you have set "--demo", you will specify a CSV inside the application.
+Unless you have set "--demo", you will specify a CSV or TSV inside the application.
 
 Provide a "Private Data" if you only have a private data set, and want to
 make a release from it: The preview visualizations will only use
@@ -61,7 +61,7 @@ read until the release.
 Provide a "Public Data" if you have a public data set, and are curious how
 DP can be applied: The preview visualizations will use your public data.
 
-Provide both if you have two CSVs with the same structure.
+Provide both if you have two CSVs or TSVs with the same structure.
 Perhaps the public data is older and no longer sensitive. Preview
 visualizations will be made with the public data, but the release will
 be made with private data.

--- a/docs/index.html
+++ b/docs/index.html
@@ -667,8 +667,8 @@ href="https://mccalluc-dp-wizard.share.connect.posit.cloud/"><code>tinyurl.com/d
 <ul>
 <li>1: On “Select Dataset”:
 <ul>
-<li>Under “CSV Columns”, enter <code>grade</code>.</li>
-<li>Leave the “Unit of Protection” at 1.</li>
+<li>A demo CSV is already provided.</li>
+<li>Leave the “Unit of Protection” at 10.</li>
 <li>Click “Define Analysis”.</li>
 </ul></li>
 </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -415,8 +415,8 @@ Then:
 <td>
 
 - 1: On "Select Dataset":
-    - Under "CSV Columns", enter `grade`.
-    - Leave the "Unit of Protection" at 1.
+    - A demo CSV is already provided.
+    - Leave the "Unit of Protection" at 10.
     - Click "Define Analysis".
 
 </td>

--- a/dp_wizard/FAQ.md
+++ b/dp_wizard/FAQ.md
@@ -1,7 +1,7 @@
 ### What does DP Wizard do?
 
 DP Wizard guides you through the application of differential privacy.
-After selecting a local CSV, you'll be prompted to describe the analysis you need.
+After selecting a local CSV or TSV, you'll be prompted to describe the analysis you need.
 Output options include:
 - A Jupyter notebook which demonstrates how to use
 the [OpenDP Library](https://docs.opendp.org/).
@@ -14,7 +14,7 @@ the [OpenDP Library](https://docs.opendp.org/).
 DP Wizard (or differential privacy more generally) is not an all-purpose privacy filter:
 It requires data of a particular form for its privacy guarantees to be valid.
 
-- **Tabular data**: While DP on other kinds of data is an active area of research (graphs or text, for example), DP Wizard is limited to CSVs.
+- **Tabular data**: While DP on other kinds of data is an active area of research (graphs or text, for example), DP Wizard is limited to CSVs and TSVs.
 - **Field / record structure**: Rows should represent records, and columns should represent fields.
 - **Individuals, not aggregates**: Further, each row should be related to a single entity whose privacy you want to protect:
 If the data has already been aggregated to a higher level, DP Wizard is not the right tool.

--- a/dp_wizard/shiny/panels/analysis_panel/__init__.py
+++ b/dp_wizard/shiny/panels/analysis_panel/__init__.py
@@ -314,7 +314,7 @@ def analysis_server(
                 Unlike the other settings on this page,
                 this estimate **is not used** in the final calculation.
 
-                Until you make a release, your CSV will not be
+                Until you make a release, your data source will not be
                 read except to determine the names of columns,
                 but the number of rows does have implications for the
                 accuracy which DP can provide with a given privacy budget.

--- a/dp_wizard/shiny/panels/dataset_panel/__init__.py
+++ b/dp_wizard/shiny/panels/dataset_panel/__init__.py
@@ -488,7 +488,7 @@ Choose both **Private Data** and **Public Data** {PUBLIC_PRIVATE_TEXT}
     @render.ui
     def max_rows_tutorial_ui():
         return (
-            ui.markdown("What is the **maximum row count** of your CSV?"),
+            ui.markdown("What is the **maximum row count** of your data source?"),
             tutorial_box(
                 is_tutorial_mode(),
                 """
@@ -514,7 +514,7 @@ Choose both **Private Data** and **Public Data** {PUBLIC_PRIVATE_TEXT}
             ui.layout_columns(
                 ui.input_text(
                     "max_rows",
-                    only_for_screenreader("Maximum number of rows in CSV"),
+                    only_for_screenreader("Maximum number of rows in data source"),
                     "",
                 ),
                 [],  # column placeholder

--- a/dp_wizard/shiny/panels/dataset_panel/__init__.py
+++ b/dp_wizard/shiny/panels/dataset_panel/__init__.py
@@ -531,10 +531,8 @@ Choose both **Private Data** and **Public Data** {PUBLIC_PRIVATE_TEXT}
             return button
         return [
             button,
-            """
-            Specify CSV, unit of protection,
-            and maximum row count before proceeding.
-            """,
+            "Specify data source, unit of protection, "
+            "and maximum row count before proceeding.",
         ]
 
     @render.ui

--- a/dp_wizard/shiny/panels/results_panel/download_options.py
+++ b/dp_wizard/shiny/panels/results_panel/download_options.py
@@ -39,7 +39,7 @@ _download_options = {
             ".ipynb",
             "book",
             """
-            An executed Jupyter notebook which references your CSV
+            An executed Jupyter notebook which references your data source
             and shows the result of a differentially private analysis.
             """,
         ),
@@ -106,7 +106,7 @@ _download_options = {
             "sliders",
             """
             Analysis configuration as YAML. Except for the contents of
-            your input CSV, this captures all the details of your analysis.
+            your data source, this captures all the details of your analysis.
             """,
             requires_release=False,
         ),

--- a/dp_wizard/types.py
+++ b/dp_wizard/types.py
@@ -53,7 +53,7 @@ class StatisticName(str):
 
 class ColumnName(str):
     """
-    The exact column header in the CSV.
+    The exact column header in the data source.
     """
 
     pass

--- a/dp_wizard/utils/argparse_helpers.py
+++ b/dp_wizard/utils/argparse_helpers.py
@@ -9,7 +9,7 @@ PRIVATE_TEXT = """if you only have a private data set, and want to
 make a release from it: The preview visualizations will only use
 simulated data, and apart from the headers, the private data is not
 read until the release."""
-PUBLIC_PRIVATE_TEXT = """if you have two CSVs with the same structure.
+PUBLIC_PRIVATE_TEXT = """if you have two CSVs or TSVs with the same structure.
 Perhaps the public data is older and no longer sensitive. Preview
 visualizations will be made with the public data, but the release will
 be made with private data."""
@@ -25,7 +25,7 @@ def _get_arg_parser() -> argparse.ArgumentParser:
         description="DP Wizard makes it easier to get started with "
         "Differential Privacy.",
         epilog=f"""
-Unless you have set "--demo", you will specify a CSV inside the application.
+Unless you have set "--demo", you will specify a CSV or TSV inside the application.
 
 Provide a "Private Data" {PRIVATE_TEXT}
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -84,7 +84,8 @@ def test_local_app_validations(page: Page, local_app: ShinyAppProc):  # pragma: 
         )
     ).to_be_visible()
     expected_error = (
-        "Specify CSV, unit of protection, and maximum row count before proceeding."
+        "Specify data source, unit of protection, "
+        "and maximum row count before proceeding."
     )
     expect(page.get_by_text(expected_error)).to_be_visible()
 


### PR DESCRIPTION
- Missed these during #879
- Fix #913
- Tried to use "or TSV" when it's talking about the particular options available, and "data source" when it's just talking about the earlier part of the UI... but if the phrasing anywhere seems awkward, please comment!
- Retained "CSV" when talking about outputs, and in the generated code, where the user TSV has already been converted.
- FYI: Filed #914, but not planning to act on that without user input.

I'm using "TSV" to suggest _any_ tab-delim file: The tutorial box explains:
> Internally, OpenDP works best with CSVs; Other formats will be converted to CSV. Any of these extensions are accepted: `.csv`, `.tsv`, `.tab`.