### PR TITLE
add "Tutorial" label

### DIFF
--- a/dp_wizard/shiny/__init__.py
+++ b/dp_wizard/shiny/__init__.py
@@ -67,15 +67,14 @@ def _make_app_ui(cli_info: CLIInfo) -> Tag:
                 ui.input_switch(
                     "tutorial_mode",
                     ui.tooltip(
-                        tutorial_icon,
+                        "Tutorial",
                         """
-                        Tutorial mode walks you through the analysis process
+                        The tutorial walks you through the process
                         and provides extra help along the way.
                         """,
-                        placement="right",
                     ),
                     value=_get_is_tutorial_mode(cli_info),
-                    width="4em",
+                    width="7em",
                 )
             ),
             ui.nav_control(

--- a/dp_wizard/shiny/__init__.py
+++ b/dp_wizard/shiny/__init__.py
@@ -4,7 +4,6 @@ from htmltools import Tag
 from shiny import App, Inputs, Outputs, Session, reactive, ui
 
 from dp_wizard import config_root, package_root
-from dp_wizard.shiny.components.icons import tutorial_icon
 from dp_wizard.shiny.panels import (
     analysis_panel,
     dataset_panel,

--- a/dp_wizard/shiny/panels/dataset_panel/__init__.py
+++ b/dp_wizard/shiny/panels/dataset_panel/__init__.py
@@ -258,9 +258,8 @@ def dataset_server(
                 demonstrates how to use the
                 [OpenDP Library](https://docs.opendp.org/).
 
-                (If you don't need these extra help messages,
-                turn them off by toggling the switch in the upper right
-                corner of the window.)
+                (If you don't need this tutorial, turn it off
+                by toggling the switch in the upper right corner.)
                 """,
             ),
         )


### PR DESCRIPTION
- Fix #855

<img width="399" height="141" alt="Screenshot 2026-03-11 at 3 36 04 PM" src="https://github.com/user-attachments/assets/e41c5252-9113-4484-9940-669afb03730c" />

It's higher than I'd like, but I spent some time wrangling the CSS, and although I was able to bring the controls down, moving the "Tutorial" down with `margin-top` also lowered the horizontal grey line, and separated it from the tab outline.

If anyone else wants to try, feel free! If this looks too ugly, don't feel obliged to approve.

There's already a little custom CSS in styles.css for this part of the UI:
```
/*
The tutorial mode toggle in the navbar is positioned slightly too high.
*/
.shiny-input-container:has(#tutorial_mode) {
    margin-top: 0.15em;
    margin-bottom: -0.15em;
}
```