### PR TITLE
simplify review workflow

### DIFF
--- a/README-TEAM.md
+++ b/README-TEAM.md
@@ -1,5 +1,22 @@
 # Team processes
 
+## Privs
+
+Privs should be assigned on a group basis, rather than granted to indivuals.
+
+## Conventions
+
+Branch names should be of the form `NNNN-short-description`, where `NNNN` is the issue number being addressed.
+
+Add developer-only dependencies in `requirements-dev.in`; Add other dependencies in `requirements.in`. After an edit to either file run `scripts/requirements.py` to install the new dependency locally and update `pyproject.toml`.
+
+## Review
+
+"Draft" can be used to indicate that a PR isn't quite ready for review.
+If it's not "draft" a reviewer should be assigned.
+
+If the situation calls for it, PRs can be stacked, but we'll try to keep things simple.
+
 ## Release
 
 ### PyPI
@@ -26,50 +43,3 @@ If you are on `main`, with no local changes, run `scripts/deploy.sh`.
 
 Run `scripts/docker.sh`: This will build and start a new image.
 Confirm that it works, and then follow the instructions in the output to push to Docker Hub.
-
-## Conventions
-
-Branch names should be of the form `NNNN-short-description`, where `NNNN` is the issue number being addressed.
-
-Add developer-only dependencies in `requirements-dev.in`; Add other dependencies in `requirements.in`. After an edit to either file run `scripts/requirements.py` to install the new dependency locally and update `pyproject.toml`.
-
-A GitHub [project board](https://github.com/orgs/opendp/projects/10/views/2) provides an overview of the issues and PRs.
-When PRs are [Ready for Review](https://github.com/orgs/opendp/projects/10/views/2?filterQuery=status%3A%22Ready+for+Review%22) they should be flagged as such so reviewers can find them.
-
-```mermaid
-graph TD
-    subgraph Pending
-        %% We only get one auto-add workflow with the free plan.
-        %% https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically
-        Issue-New
-        PR-New-or-Changes
-    end
-    %% subgraph In Progress
-        %% How should this be used?
-        %% Can it be automated
-    %% end
-    subgraph Ready for Review
-        PR-for-Review
-    end
-    subgraph In Review
-        PR-in-Review --> PR-Approved
-    end
-    subgraph Done
-        Issue-Closed
-        PR-Merged
-        PR-Closed
-    end
-    PR-New-or-Changes -->|manual| PR-for-Review
-    PR-for-Review -->|manual| PR-in-Review
-    Issue-New -->|auto| Issue-Closed
-    PR-New-or-Changes -->|auto| PR-Closed
-    PR-for-Review -->|auto| PR-Closed
-    PR-in-Review -->|auto| PR-Closed
-    PR-for-Review -->|manual| PR-New-or-Changes
-    PR-in-Review -->|auto| PR-New-or-Changes
-    PR-Approved -->|auto| PR-Merged
-```
-- For `manual` transitions, the status of the issue or PR will need to be updated by hand, either on the issue, or by dragging between columns on the board.
-- For `auto` transitions, some other action (for example, approving a PR) should trigger a [workflow](https://github.com/orgs/opendp/projects/10/workflows).
-- These are the only states that matter. Whether PR is a draft or has assignees does not matter.
-- If we need anything more than this, we should consider a paid plan, so that we have access to more workflows.


### PR DESCRIPTION
If this is approved, we can also turn off "Projects" for this repo. The built-in status info on issues will be enough.

- Fix #926