### PR TITLE
Add OpenDP Commons note;  upgrade opendp

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -7,7 +7,7 @@ the addition of calibrated noise to aggregate statistics to protect the privacy 
 DP Wizard demonstrates how to calculate DP statistics or create a synthetic dataset from the data you provide.
 
 > [!NOTE]
-> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> This software is part of the [**OpenDP Commons**](https://opendp.org/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
 > - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -11,7 +11,7 @@ DP Wizard demonstrates how to calculate DP statistics or create a synthetic data
 > - Releasing this software under an [OSI approved license](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
-> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focused not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
 
 If differential privacy is new to you, [these slides](https://opendp.github.io/dp-wizard/) provide some background, and explain how DP Wizard works.
 

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -8,7 +8,7 @@ DP Wizard demonstrates how to calculate DP statistics or create a synthetic data
 
 > [!NOTE]
 > This software is part of the [**OpenDP Commons**](https://opendp.org/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
-> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
+> - Releasing this software under an [OSI approved license](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 > - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -6,6 +6,13 @@ DP Wizard makes it easier to get started with differential privacy,
 the addition of calibrated noise to aggregate statistics to protect the privacy of individuals.
 DP Wizard demonstrates how to calculate DP statistics or create a synthetic dataset from the data you provide.
 
+> [!NOTE]
+> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
+> - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
+> - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
+
 If differential privacy is new to you, [these slides](https://opendp.github.io/dp-wizard/) provide some background, and explain how DP Wizard works.
 
 Options for running DP Wizard:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the addition of calibrated noise to aggregate statistics to protect the privacy 
 DP Wizard demonstrates how to calculate DP statistics or create a synthetic dataset from the data you provide.
 
 > [!NOTE]
-> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> This software is part of the [**OpenDP Commons**](https://opendp.org/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
 > - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DP Wizard demonstrates how to calculate DP statistics or create a synthetic data
 > - Releasing this software under an [OSI approved license](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
-> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focused not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
 
 If differential privacy is new to you, [these slides](https://opendp.github.io/dp-wizard/) provide some background, and explain how DP Wizard works.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DP Wizard demonstrates how to calculate DP statistics or create a synthetic data
 
 > [!NOTE]
 > This software is part of the [**OpenDP Commons**](https://opendp.org/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
-> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
+> - Releasing this software under an [OSI approved license](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
 > - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
 > - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
 > - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ DP Wizard makes it easier to get started with differential privacy,
 the addition of calibrated noise to aggregate statistics to protect the privacy of individuals.
 DP Wizard demonstrates how to calculate DP statistics or create a synthetic dataset from the data you provide.
 
+> [!NOTE]
+> This software is part of the [**OpenDP Commons**](https://sites.harvard.edu/opendp/tools/#opendp-commons). As such, the OpenDP Executive Committee commits to:
+> - Releasing this software under an [OSI approved licence](https://opensource.org/licenses), in this case the [MIT License](https://github.com/opendp/opendp/blob/main/LICENSE).
+> - Ensuring there are at least two maintainers, in this case Eddie de Leon (`eddiestudies`) and Chuck McCallum (`mccalluc`), who will respond within a week to new issues and PRs.
+> - Only making changes on `main` through PRs, and getting approval on these PRs before merging.
+> - On an annual basis, recruiting one or more volunteers (not active contributors) who will conduct a health-check, focussed not on the details of the algorithms but on the health of this repo as open source software. Their report will be linked here. The next (and first) health-check is scheduled for September 2026.
+
 If differential privacy is new to you, [these slides](https://opendp.github.io/dp-wizard/) provide some background, and explain how DP Wizard works.
 
 Options for running DP Wizard:

--- a/docs/index.html
+++ b/docs/index.html
@@ -736,7 +736,7 @@ going on here, see the documentation for OpenDP:
 https://docs.opendp.org/</p>
 <h4 id="prerequisites">Prerequisites</h4>
 <p>First install and import the required dependencies:</p>
-<pre><code>%pip install &#39;opendp[polars]==0.14.1&#39; matplotlib</code></pre>
+<pre><code>%pip install &#39;opendp[polars]==0.14.2&#39; matplotlib</code></pre>
 <pre><code>&gt;&gt;&gt; import matplotlib.pyplot as plt
 &gt;&gt;&gt; import opendp.prelude as dp
 &gt;&gt;&gt; import polars as pl
@@ -770,7 +770,7 @@ Polars expression that describes how we want to summarize that
 column.</p>
 <h3 id="expression-for-grade">Expression for <code>grade</code></h3>
 <pre><code>&gt;&gt;&gt; # See the OpenDP Library docs for more on making private histograms:
-&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.1/getting-started/examples/histograms.html
+&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.2/getting-started/examples/histograms.html
 &gt;&gt;&gt;
 &gt;&gt;&gt; # Use the public information to make cut points for &#39;grade&#39;:
 &gt;&gt;&gt; grade_cut_points = make_cut_points(
@@ -801,7 +801,7 @@ budget, and set the weight for each query under that overall budget.</p>
 ... )
 &gt;&gt;&gt;
 &gt;&gt;&gt; # See the OpenDP Library docs for more on Context:
-&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.1/api/user-guide/context/index.html#context
+&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.2/api/user-guide/context/index.html#context
 &gt;&gt;&gt; stats_context = dp.Context.compositor(
 ...     data=pl.scan_csv(
 ...         &quot;docs/fill-in-correct-path.csv&quot;,
@@ -873,13 +873,13 @@ most well developed.</li>
 <h3 id="with-opendp">With OpenDP</h3>
 <ul>
 <li>(<a
-href="https://docs.opendp.org/en/v0.14.1/api/user-guide/transformations/aggregation-quantile.html">Quantiles</a>)</li>
+href="https://docs.opendp.org/en/v0.14.2/api/user-guide/transformations/aggregation-quantile.html">Quantiles</a>)</li>
 <li>(<a
-href="https://docs.opendp.org/en/v0.14.1/getting-started/statistical-modeling/pca.html">PCA</a>)</li>
+href="https://docs.opendp.org/en/v0.14.2/getting-started/statistical-modeling/pca.html">PCA</a>)</li>
 <li>(<a
-href="https://docs.opendp.org/en/v0.14.1/api/python/opendp.measurements.html#opendp.measurements.make_randomized_response_bitvec">RAPPOR</a>)</li>
+href="https://docs.opendp.org/en/v0.14.2/api/python/opendp.measurements.html#opendp.measurements.make_randomized_response_bitvec">RAPPOR</a>)</li>
 <li>(<a
-href="https://docs.opendp.org/en/v0.14.1/api/python/opendp.extras.sklearn.linear_model.html">Linear
+href="https://docs.opendp.org/en/v0.14.2/api/python/opendp.extras.sklearn.linear_model.html">Linear
 regression</a>)</li>
 </ul>
 </td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -770,7 +770,7 @@ Polars expression that describes how we want to summarize that
 column.</p>
 <h3 id="expression-for-grade">Expression for <code>grade</code></h3>
 <pre><code>&gt;&gt;&gt; # See the OpenDP Library docs for more on making private histograms:
-&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.2/getting-started/examples/histograms.html
+&gt;&gt;&gt; # https://docs.opendp.org/en/v0.14.2/getting-started/tabular-data/grouping.html
 &gt;&gt;&gt;
 &gt;&gt;&gt; # Use the public information to make cut points for &#39;grade&#39;:
 &gt;&gt;&gt; grade_cut_points = make_cut_points(

--- a/docs/index.md
+++ b/docs/index.md
@@ -516,7 +516,7 @@ Based on the input you provided, for each column we'll create a Polars expressio
 
 ```
 >>> # See the OpenDP Library docs for more on making private histograms:
->>> # https://docs.opendp.org/en/v0.14.2/getting-started/examples/histograms.html
+>>> # https://docs.opendp.org/en/v0.14.2/getting-started/tabular-data/grouping.html
 >>>
 >>> # Use the public information to make cut points for 'grade':
 >>> grade_cut_points = make_cut_points(

--- a/docs/index.md
+++ b/docs/index.md
@@ -476,7 +476,7 @@ This is a demonstration of how the OpenDP Library can be used to create a differ
 First install and import the required dependencies:
 
 ```
-%pip install 'opendp[polars]==0.14.1' matplotlib
+%pip install 'opendp[polars]==0.14.2' matplotlib
 ```
 ```
 >>> import matplotlib.pyplot as plt
@@ -516,7 +516,7 @@ Based on the input you provided, for each column we'll create a Polars expressio
 
 ```
 >>> # See the OpenDP Library docs for more on making private histograms:
->>> # https://docs.opendp.org/en/v0.14.1/getting-started/examples/histograms.html
+>>> # https://docs.opendp.org/en/v0.14.2/getting-started/examples/histograms.html
 >>>
 >>> # Use the public information to make cut points for 'grade':
 >>> grade_cut_points = make_cut_points(
@@ -549,7 +549,7 @@ Next, we'll define our Context. This is where we set the privacy budget, and set
 ... )
 >>>
 >>> # See the OpenDP Library docs for more on Context:
->>> # https://docs.opendp.org/en/v0.14.1/api/user-guide/context/index.html#context
+>>> # https://docs.opendp.org/en/v0.14.2/api/user-guide/context/index.html#context
 >>> stats_context = dp.Context.compositor(
 ...     data=pl.scan_csv(
 ...         "docs/fill-in-correct-path.csv",
@@ -626,10 +626,10 @@ If we try to run more queries at this point, it will error. Once the privacy bud
 
 ### With OpenDP
 
-- ([Quantiles](https://docs.opendp.org/en/v0.14.1/api/user-guide/transformations/aggregation-quantile.html))
-- ([PCA](https://docs.opendp.org/en/v0.14.1/getting-started/statistical-modeling/pca.html))
-- ([RAPPOR](https://docs.opendp.org/en/v0.14.1/api/python/opendp.measurements.html#opendp.measurements.make_randomized_response_bitvec))
-- ([Linear regression](https://docs.opendp.org/en/v0.14.1/api/python/opendp.extras.sklearn.linear_model.html))
+- ([Quantiles](https://docs.opendp.org/en/v0.14.2/api/user-guide/transformations/aggregation-quantile.html))
+- ([PCA](https://docs.opendp.org/en/v0.14.2/getting-started/statistical-modeling/pca.html))
+- ([RAPPOR](https://docs.opendp.org/en/v0.14.2/api/python/opendp.measurements.html#opendp.measurements.make_randomized_response_bitvec))
+- ([Linear regression](https://docs.opendp.org/en/v0.14.2/api/python/opendp.extras.sklearn.linear_model.html))
 
 </td>
 <td>

--- a/dp_wizard/__init__.py
+++ b/dp_wizard/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 package_root = Path(__file__).parent
 __version__ = (package_root / "VERSION").read_text().strip()
-opendp_version = "0.14.1"
+opendp_version = "0.14.2"
 registry_url = "https://registry.opendp.org/deployments-registry/"
 config_root = Path(os.path.expanduser("~")) / ".dp-wizard"
 if not config_root.exists():

--- a/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_expr.py
+++ b/dp_wizard/utils/code_generators/analyses/histogram/no-tests/_histogram_expr.py
@@ -1,5 +1,5 @@
 # See the OpenDP Library docs for more on making private histograms:
-# https://docs.opendp.org/en/OPENDP_V_VERSION/getting-started/examples/histograms.html
+# https://docs.opendp.org/en/OPENDP_V_VERSION/getting-started/tabular-data/grouping.html
 
 # Use the public information to make cut points for COLUMN_NAME:
 CUT_LIST_NAME = make_cut_points(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "dp-wizard-templates==0.8.2",
     "faicons",
     "matplotlib",
-    "opendp[mbi]==0.14.1",
+    "opendp[mbi]==0.14.2",
     "shiny",
 ]
 
@@ -118,7 +118,7 @@ pins = [
     "nest-asyncio==1.6.0",
     "networkx==3.4.2",
     "numpy==2.2.4",
-    "opendp[mbi]==0.14.1",
+    "opendp[mbi]==0.14.2",
     "opt-einsum==3.4.0",
     "optax==0.2.5",
     "orjson==3.10.16",

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,7 +6,7 @@ flit
 flake8
 flake8-bugbear
 pre-commit
-tomlkit
+tomlkit==0.13.2  # Newer versions cause ValueError; Will be dropping in favor of uv.
 isort
 black
 autoflake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -242,7 +242,7 @@ numpy==2.2.4
     #   randomgen
     #   scikit-learn
     #   scipy
-opendp[mbi]==0.14.1
+opendp[mbi]==0.14.2
     # via -r .../dp-wizard/requirements.in
 opt-einsum==3.4.0
     # via jax

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # After making changes here, run scripts/requirements.py.
 
 # OpenDP:
-opendp[mbi]==0.14.1
+opendp[mbi]==0.14.2
 
 # Templating and notebook generation:
 dp-wizard-templates==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -182,7 +182,7 @@ numpy==2.2.4
     #   randomgen
     #   scikit-learn
     #   scipy
-opendp[mbi]==0.14.1
+opendp[mbi]==0.14.2
     # via -r requirements.in
 opt-einsum==3.4.0
     # via jax

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -69,7 +69,7 @@ def test_python_min_version(rel_path):
 
 @pytest.mark.parametrize(
     "script_path",
-    (package_root.parent / "scripts").glob("*.sh"),
+    list((package_root.parent / "scripts").glob("*.sh")),
     ids=lambda path: path.name,
 )
 def test_bash_scripts(script_path: Path):

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -7,18 +7,18 @@ import opendp.prelude as dp
 import polars as pl
 import pytest
 import requests
+from dp_wizard.types import ColumnName, CsvInfo, Product, StatisticName
+from dp_wizard.utils.code_generators.notebook_generator import NotebookGenerator
+from dp_wizard.utils.code_generators.script_generator import ScriptGenerator
 from dp_wizard_templates.converters import convert_from_notebook, convert_to_notebook
 
 from dp_wizard import opendp_version, package_root
-from dp_wizard.types import ColumnName, CsvInfo, Product, StatisticName
 from dp_wizard.utils.code_generators import (
     AnalysisPlan,
     AnalysisPlanColumn,
     make_column_config_block,
 )
 from dp_wizard.utils.code_generators.analyses import histogram, mean, median
-from dp_wizard.utils.code_generators.notebook_generator import NotebookGenerator
-from dp_wizard.utils.code_generators.script_generator import ScriptGenerator
 
 python_paths = list(package_root.glob("**/*.py"))
 
@@ -87,7 +87,7 @@ def test_make_column_config_block_for_histogram():
             bin_count=10,
         ).strip()
         == f"""# See the OpenDP Library docs for more on making private histograms:
-# https://docs.opendp.org/en/v{opendp_version}/getting-started/examples/histograms.html
+# https://docs.opendp.org/en/v{opendp_version}/getting-started/tabular-data/grouping.html
 
 # Use the public information to make cut points for 'HW GRADE':
 hw_grade_cut_points = make_cut_points(

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -187,8 +187,8 @@ plans = [plan for i, plan in enumerate(plans_all_combos) if i % mod == 0]
 expected_urls = [
     "https://docs.opendp.org/",
     "https://github.com/opendp/dp-wizard",
-    "https://docs.opendp.org/en/v0.14.1/api/python/opendp.extras.mbi.html#opendp.extras.mbi.ContingencyTable.synthesize",
-    "https://docs.opendp.org/en/v0.14.1/api/python/opendp.extras.mbi.html#opendp.extras.mbi.ContingencyTable.project_melted",
+    "https://docs.opendp.org/en/v0.14.2/api/python/opendp.extras.mbi.html#opendp.extras.mbi.ContingencyTable.synthesize",
+    "https://docs.opendp.org/en/v0.14.2/api/python/opendp.extras.mbi.html#opendp.extras.mbi.ContingencyTable.project_melted",
 ]
 
 

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -7,18 +7,18 @@ import opendp.prelude as dp
 import polars as pl
 import pytest
 import requests
-from dp_wizard.types import ColumnName, CsvInfo, Product, StatisticName
-from dp_wizard.utils.code_generators.notebook_generator import NotebookGenerator
-from dp_wizard.utils.code_generators.script_generator import ScriptGenerator
 from dp_wizard_templates.converters import convert_from_notebook, convert_to_notebook
 
 from dp_wizard import opendp_version, package_root
+from dp_wizard.types import ColumnName, CsvInfo, Product, StatisticName
 from dp_wizard.utils.code_generators import (
     AnalysisPlan,
     AnalysisPlanColumn,
     make_column_config_block,
 )
 from dp_wizard.utils.code_generators.analyses import histogram, mean, median
+from dp_wizard.utils.code_generators.notebook_generator import NotebookGenerator
+from dp_wizard.utils.code_generators.script_generator import ScriptGenerator
 
 python_paths = list(package_root.glob("**/*.py"))
 

--- a/tests/utils/test_code_generators.py
+++ b/tests/utils/test_code_generators.py
@@ -20,7 +20,7 @@ from dp_wizard.utils.code_generators.analyses import histogram, mean, median
 from dp_wizard.utils.code_generators.notebook_generator import NotebookGenerator
 from dp_wizard.utils.code_generators.script_generator import ScriptGenerator
 
-python_paths = package_root.glob("**/*.py")
+python_paths = list(package_root.glob("**/*.py"))
 
 
 @pytest.mark.parametrize("python_path", python_paths, ids=lambda path: path.name)


### PR DESCRIPTION
Duplicate READMEs will go away with the uv migration, so don't worry about that.

Salil confirmed that this has approval from the Exec Com. Thought it would be better to merge this PR before updating https://opendp.org/tools/#opendp-commons

Similar PR will be added in Tumult.